### PR TITLE
step-1: employee specs (md+json) + export script + regex tests + docs guard

### DIFF
--- a/.github/workflows/docs-guard.yml
+++ b/.github/workflows/docs-guard.yml
@@ -1,0 +1,18 @@
+name: docs-guard
+on:
+  pull_request:
+    branches: [ main ]
+  push:
+    branches: [ main ]
+jobs:
+  docs-guard:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Run docs guard
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          Set-StrictMode -Version Latest
+          ./PS1/specs/export_employe.ps1
+          ./PS1/tools/docs_guard.ps1

--- a/PS1/smoke.ps1
+++ b/PS1/smoke.ps1
@@ -4,4 +4,11 @@ Set-StrictMode -Version Latest
 Write-Host "[smoke] Roadmap quick check..."
 & "$PSScriptRoot\tools\roadmap_guard.ps1" -Quick
 
+Write-Host "[smoke] Export employee spec (quick)..."
+& "$PSScriptRoot\specs\export_employe.ps1"
+
+Write-Host "[smoke] Email regex quick test..."
+& "$PSScriptRoot\tests\spec_employee_email_regex.ps1"
+
+Write-Host "[smoke] OK"
 Exit 0

--- a/PS1/specs/export_employe.ps1
+++ b/PS1/specs/export_employe.ps1
@@ -1,0 +1,119 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$root = Resolve-Path "$PSScriptRoot\..\.."
+$specDir = Join-Path $root "docs\specs"
+New-Item -ItemType Directory -Force -Path $specDir | Out-Null
+
+# JSON
+$jsonPath = Join-Path $specDir "employee_v1.json"
+$json = @'
+{ "version": "1.0.0", "entity": "employee",
+  "fields": [
+    {"name":"id","type":"uuid","required":true},
+    {"name":"nom","type":"string","required":true,"min_length":2,"max_length":100},
+    {"name":"prenom","type":"string","required":true,"min_length":1,"max_length":100},
+    {"name":"email","type":"string","required":true,"unique":true,"pattern":"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"},
+    {"name":"telephone","type":"string","required":false,"pattern":"^[0-9+(). -]{7,20}$"},
+    {"name":"role_metier","type":"string","required":false,"enum":["regisseur","technicien","administratif","autre"]},
+    {"name":"service","type":"string","required":false,"nullable":true},
+    {"name":"site","type":"string","required":false,"nullable":true},
+    {"name":"statut","type":"string","required":false,"enum":["actif","inactif","archive"],"default":"actif"},
+    {"name":"date_entree","type":"date","required":false,"nullable":true},
+    {"name":"date_sortie","type":"date","required":false,"nullable":true},
+    {"name":"contrat_type","type":"string","required":false,"enum":["CDI","CDD","Intermittent","Freelance","Stage","Autre"]},
+    {"name":"temps_travail","type":"number","required":false,"min":0,"max":100},
+    {"name":"manager_id","type":"uuid","required":false,"nullable":true,"relation":"employee.id"}
+  ],
+  "constraints": [
+    {"name":"email_unique","type":"unique","fields":["email"]},
+    {"name":"manager_not_self","type":"check","expression":"manager_id IS NULL OR manager_id <> id"},
+    {"name":"date_sortie_after_entree","type":"check","expression":"date_sortie IS NULL OR date_entree IS NULL OR date_sortie >= date_entree"}
+  ],
+  "pagination":{"default_limit":25,"max_limit":200},
+  "identifiers":{"primary_key":["id"],"natural_key":["email"]},
+  "validation":{"email_regex":"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$","telephone_regex":"^[0-9+(). -]{7,20}$"}
+}
+'@
+Set-Content -LiteralPath $jsonPath -Value $json -Encoding UTF8
+
+# Markdown
+$mdPath = Join-Path $specDir "employee_v1.md"
+$md = @'
+# Spec fonctionnelle - Employe v1
+
+Version: 1.0.0  
+Objet: definir le modele Employe, les contraintes metier et le plan d'API CRUD.
+
+## Modele de donnees (champ -> type -> contraintes)
+- id: uuid, PK, requis.
+- nom: string, 2..100, requis.
+- prenom: string, 1..100, requis.
+- email: string, requis, unique, format email (regex ci-dessous).
+- telephone: string, optionnel, pattern: ^[0-9+(). -]{7,20}$ .
+- role_metier: string, enum ex: regisseur|technicien|administratif|autre (ouvert).
+- service: string, optionnel (code ou libelle).
+- site: string, optionnel (code ou libelle).
+- statut: string, enum: actif|inactif|archive (defaut: actif).
+- date_entree: date, optionnel.
+- date_sortie: date, optionnel, >= date_entree si presente.
+- contrat_type: string, enum: CDI|CDD|Intermittent|Freelance|Stage|Autre.
+- temps_travail: number (0..100), pourcentage d'equivalent temps plein.
+- manager_id: uuid, optionnel, FK -> Employe.id, ne peut pas pointer vers soi-meme.
+
+### Contraintes
+- email unique (natural key).
+- manager_not_self: manager_id IS NULL OR manager_id != id.
+- date_sortie_after_entree: date_sortie IS NULL OR date_entree IS NULL OR date_sortie >= date_entree.
+
+### Regex email (v1, pragmatique)
+```
+^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$
+```
+Note: regex volontairement simple; elle sera remplacee par une validation cote backend plus robuste (RFC partielle).
+
+## Plan API preliminaire (CRUD) - prefix /api/v1
+- GET /employees?limit=25&offset=0&search=... -> liste paginee (defaut limit 25, max 200).
+- GET /employees/{id} -> detail.
+- POST /employees -> creation (valide champs + unicite email).
+- PATCH /employees/{id} -> MAJ partielle.
+- DELETE /employees/{id} -> suppression logique (statut=archive) ou dure suivant politique.
+
+Reponses: JSON, pagination par defaut (limit/offset, total), erreurs JSON structurees (code, message, details).
+
+## Diagramme (ASCII)
+```
++---------------------------+
+|         EMPLOYEE         |
++---------------------------+
+| id : uuid (PK)           |
+| nom : string             |
+| prenom : string          |
+| email : string (UNIQUE)  |
+| telephone : string       |
+| role_metier : string     |
+| service : string?        |
+| site : string?           |
+| statut : string          |
+| date_entree : date?      |
+| date_sortie : date?      |
+| contrat_type : string    |
+| temps_travail : number   |
+| manager_id : uuid? (FK)  |
++---------------------------+
+manager_id -> EMPLOYEE.id (0..1 manager, 0..N subordonnes)
+```
+
+## Exemples
+- OK: samuel.aubron+test@exemple.fr
+- KO: invalid-email
+
+## Versionning
+- v1.0.0: premiere version documentee. Les evolutions seront pistees dans employee_v1.json (champ version) et CHANGELOG.
+
+---
+'@
+Set-Content -LiteralPath $mdPath -Value $md -Encoding UTF8
+
+Write-Host "export_employe: wrote $jsonPath and $mdPath"
+Exit 0

--- a/PS1/test_all.ps1
+++ b/PS1/test_all.ps1
@@ -4,4 +4,11 @@ Set-StrictMode -Version Latest
 Write-Host "[test_all] Running roadmap guard..."
 & "$PSScriptRoot\tools\roadmap_guard.ps1"
 
+Write-Host "[test_all] Exporting employee spec..."
+& "$PSScriptRoot\specs\export_employe.ps1"
+
+Write-Host "[test_all] Running spec email regex tests..."
+& "$PSScriptRoot\tests\spec_employee_email_regex.ps1"
+
+Write-Host "[test_all] DONE"
 Exit 0

--- a/PS1/tests/spec_employee_email_regex.ps1
+++ b/PS1/tests/spec_employee_email_regex.ps1
@@ -1,0 +1,46 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$root = Resolve-Path "$PSScriptRoot\..\.."
+$specJson = Join-Path $root "docs\specs\employee_v1.json"
+if (-not (Test-Path $specJson)) {
+  Write-Error "spec test: missing $specJson. Run PS1\specs\export_employe.ps1 first."
+}
+
+$spec = Get-Content -Raw -LiteralPath $specJson | ConvertFrom-Json -ErrorAction Stop
+$regex = $spec.validation.email_regex
+if ([string]::IsNullOrWhiteSpace($regex)) {
+  Write-Error "spec test: email_regex missing in spec."
+}
+
+$valids = @(
+  "samuel.aubron+test@exemple.fr",
+  "x@x.fr",
+  "user.name-123@sub.domain.co"
+)
+$invalids = @(
+  "invalid-email",
+  "foo@bar",
+  "foo@bar.",
+  " foo@bar.com "
+)
+
+$fail = $false
+foreach ($v in $valids) {
+  if ($v -notmatch $regex) {
+    Write-Host "[KO] expected valid but failed: $v"
+    $fail = $true
+  } else {
+    Write-Host "[OK] valid: $v"
+  }
+}
+foreach ($v in $invalids) {
+  if ($v -match $regex) {
+    Write-Host "[KO] expected invalid but matched: $v"
+    $fail = $true
+  } else {
+    Write-Host "[OK] invalid rejected: $v"
+  }
+}
+
+if ($fail) { exit 1 } else { Write-Host "spec email regex tests: PASS"; exit 0 }

--- a/PS1/tools/docs_guard.ps1
+++ b/PS1/tools/docs_guard.ps1
@@ -1,0 +1,26 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$root = Resolve-Path "$PSScriptRoot\..\.."
+$readme = Join-Path $root "README.md"
+$index = Join-Path $root "docs\roadmap\index.md"
+$specMd = "docs/specs/employee_v1.md"
+$specJson = "docs/specs/employee_v1.json"
+
+if (-not (Test-Path $readme)) { Write-Error "docs_guard: README.md missing" }
+if (-not (Test-Path $index)) { Write-Error "docs_guard: docs/roadmap/index.md missing" }
+
+$readmeText = Get-Content -Raw -LiteralPath $readme
+$indexText  = Get-Content -Raw -LiteralPath $index
+
+if ($readmeText -notmatch [regex]::Escape($specMd)) {
+  Write-Error "docs_guard: README must reference $specMd"
+}
+if ($indexText -notmatch "Employe v1") {
+  Write-Error "docs_guard: index.md must mention Employe v1"
+}
+if (-not (Test-Path (Join-Path $root $specMd))) { Write-Error "docs_guard: $specMd missing" }
+if (-not (Test-Path (Join-Path $root $specJson))) { Write-Error "docs_guard: $specJson missing" }
+
+Write-Host "docs_guard: OK"
+Exit 0

--- a/README.md
+++ b/README.md
@@ -15,6 +15,28 @@ La roadmap est scindee en 20 fichiers de 10 etapes chacun sous `docs/roadmap`.
 Consulter `docs/roadmap/index.md` pour l'index, les themes, et les regles d'edition.
 Le job CI `roadmap-guard` valide la coherence (fichiers, etapes, sections).
 
+## Specs RH (Etape 1)
+- Spec: `docs/specs/employee_v1.md` (version 1.0.0) et JSON `docs/specs/employee_v1.json`.
+- Export (regenerer):  
+```
+
+pwsh -NoLogo -NoProfile -File PS1\specs\export_employe.ps1
+
+```
+- Tests (regex email, 1 OK + 1 KO):  
+```
+
+pwsh -NoLogo -NoProfile -File PS1\tests\spec_employee_email_regex.ps1
+
+```
+- Packs rapides:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\smoke.ps1
+pwsh -NoLogo -NoProfile -File PS1\test_all.ps1
+
+```
+
 ## Scripts
 - `PS1\dev_up.ps1` : mise en route locale (etape 0: no-op).
 - `PS1\test_all.ps1` : lance le garde-fou de la roadmap.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -7,6 +7,7 @@ Chaque etape contient: Titre, Objectif, Livrables, Scripts, Tests, CI Gates, Acc
 
 ## Table des fichiers (10 etapes par fichier)
 - **roadmap_01-10.md (Actif)** : RH de base & planification (1-10) — Etapes detaillees (specs, tests, criteres).
+  - Etape 1 - Gestion des employes: spec Employe v1 -> docs/specs/employee_v1.md (v1.0.0).
 - roadmap_11-20.md : RH de base & planification (11-20)
 - roadmap_21-30.md : Conges, absences, temps (21-30)
 - roadmap_31-40.md : Conges, absences, temps (31-40)

--- a/docs/roadmap/roadmap_01-10.md
+++ b/docs/roadmap/roadmap_01-10.md
@@ -6,7 +6,7 @@
 Objectif:
   Mettre en place le socle conceptuel pour la gestion des salaries (modele de donnees cible, champs requis, contraintes). Preparer le plan d’API CRUD et les regles de validation.
 Livrables:
-  - Spec fonctionnelle "Employe v1" (champs: id, nom, prenom, email, telephone, role_metier, service, site, statut, date_entree, date_sortie, contrat_type, temps_travail, manager_id).
+  - Spec fonctionnelle "Employe v1" (docs/specs/employee_v1.md) (champs: id, nom, prenom, email, telephone, role_metier, service, site, statut, date_entree, date_sortie, contrat_type, temps_travail, manager_id).
   - Spec API preliminaire (CRUD /api/v1/employees : GET list/detail, POST, PATCH, DELETE; pagination par defaut).
   - Diagramme de donnees (simple): Employe (1) -> (0..1) Manager (self-reference).
 Scripts:

--- a/docs/specs/employee_v1.json
+++ b/docs/specs/employee_v1.json
@@ -1,0 +1,26 @@
+{ "version": "1.0.0", "entity": "employee",
+  "fields": [
+    {"name":"id","type":"uuid","required":true},
+    {"name":"nom","type":"string","required":true,"min_length":2,"max_length":100},
+    {"name":"prenom","type":"string","required":true,"min_length":1,"max_length":100},
+    {"name":"email","type":"string","required":true,"unique":true,"pattern":"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$"},
+    {"name":"telephone","type":"string","required":false,"pattern":"^[0-9+(). -]{7,20}$"},
+    {"name":"role_metier","type":"string","required":false,"enum":["regisseur","technicien","administratif","autre"]},
+    {"name":"service","type":"string","required":false,"nullable":true},
+    {"name":"site","type":"string","required":false,"nullable":true},
+    {"name":"statut","type":"string","required":false,"enum":["actif","inactif","archive"],"default":"actif"},
+    {"name":"date_entree","type":"date","required":false,"nullable":true},
+    {"name":"date_sortie","type":"date","required":false,"nullable":true},
+    {"name":"contrat_type","type":"string","required":false,"enum":["CDI","CDD","Intermittent","Freelance","Stage","Autre"]},
+    {"name":"temps_travail","type":"number","required":false,"min":0,"max":100},
+    {"name":"manager_id","type":"uuid","required":false,"nullable":true,"relation":"employee.id"}
+  ],
+  "constraints": [
+    {"name":"email_unique","type":"unique","fields":["email"]},
+    {"name":"manager_not_self","type":"check","expression":"manager_id IS NULL OR manager_id <> id"},
+    {"name":"date_sortie_after_entree","type":"check","expression":"date_sortie IS NULL OR date_entree IS NULL OR date_sortie >= date_entree"}
+  ],
+  "pagination":{"default_limit":25,"max_limit":200},
+  "identifiers":{"primary_key":["id"],"natural_key":["email"]},
+  "validation":{"email_regex":"^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\\.[A-Za-z]{2,}$","telephone_regex":"^[0-9+(). -]{7,20}$"}
+}

--- a/docs/specs/employee_v1.md
+++ b/docs/specs/employee_v1.md
@@ -1,0 +1,72 @@
+# Spec fonctionnelle - Employe v1
+
+Version: 1.0.0  
+Objet: definir le modele Employe, les contraintes metier et le plan d'API CRUD.
+
+## Modele de donnees (champ -> type -> contraintes)
+- id: uuid, PK, requis.
+- nom: string, 2..100, requis.
+- prenom: string, 1..100, requis.
+- email: string, requis, unique, format email (regex ci-dessous).
+- telephone: string, optionnel, pattern: ^[0-9+(). -]{7,20}$ .
+- role_metier: string, enum ex: regisseur|technicien|administratif|autre (ouvert).
+- service: string, optionnel (code ou libelle).
+- site: string, optionnel (code ou libelle).
+- statut: string, enum: actif|inactif|archive (defaut: actif).
+- date_entree: date, optionnel.
+- date_sortie: date, optionnel, >= date_entree si presente.
+- contrat_type: string, enum: CDI|CDD|Intermittent|Freelance|Stage|Autre.
+- temps_travail: number (0..100), pourcentage d'equivalent temps plein.
+- manager_id: uuid, optionnel, FK -> Employe.id, ne peut pas pointer vers soi-meme.
+
+### Contraintes
+- email unique (natural key).
+- manager_not_self: manager_id IS NULL OR manager_id != id.
+- date_sortie_after_entree: date_sortie IS NULL OR date_entree IS NULL OR date_sortie >= date_entree.
+
+### Regex email (v1, pragmatique)
+```
+^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$
+```
+Note: regex volontairement simple; elle sera remplacee par une validation cote backend plus robuste (RFC partielle).
+
+## Plan API preliminaire (CRUD) - prefix /api/v1
+- GET /employees?limit=25&offset=0&search=... -> liste paginee (defaut limit 25, max 200).
+- GET /employees/{id} -> detail.
+- POST /employees -> creation (valide champs + unicite email).
+- PATCH /employees/{id} -> MAJ partielle.
+- DELETE /employees/{id} -> suppression logique (statut=archive) ou dure suivant politique.
+
+Reponses: JSON, pagination par defaut (limit/offset, total), erreurs JSON structurees (code, message, details).
+
+## Diagramme (ASCII)
+```
++---------------------------+
+|         EMPLOYEE         |
++---------------------------+
+| id : uuid (PK)           |
+| nom : string             |
+| prenom : string          |
+| email : string (UNIQUE)  |
+| telephone : string       |
+| role_metier : string     |
+| service : string?        |
+| site : string?           |
+| statut : string          |
+| date_entree : date?      |
+| date_sortie : date?      |
+| contrat_type : string    |
+| temps_travail : number   |
+| manager_id : uuid? (FK)  |
++---------------------------+
+manager_id -> EMPLOYEE.id (0..1 manager, 0..N subordonnes)
+```
+
+## Exemples
+- OK: samuel.aubron+test@exemple.fr
+- KO: invalid-email
+
+## Versionning
+- v1.0.0: premiere version documentee. Les evolutions seront pistees dans employee_v1.json (champ version) et CHANGELOG.
+
+---


### PR DESCRIPTION
## Summary
- add employee_v1 spec in Markdown and JSON
- export script for employee spec and regex validation tests
- docs guard script and CI workflow referencing spec, plus roadmap/README updates

## Testing
- `pwsh -NoLogo -NoProfile -File PS1/specs/export_employe.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/tests/spec_employee_email_regex.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/tools/docs_guard.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/smoke.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/test_all.ps1`


------
https://chatgpt.com/codex/tasks/task_e_68b764d3ee608330b8878890c0b51cd2