### PR TITLE
step-3: RBAC v1 specs (CSV+MD) + export + tests + docs updates

### DIFF
--- a/PS1/smoke.ps1
+++ b/PS1/smoke.ps1
@@ -16,5 +16,10 @@ Write-Host "[smoke] Export orgchart spec..."
 Write-Host "[smoke] Org hierarchy quick test..."
 & "$PSScriptRoot\tests\spec_org_hierarchy.ps1"
 
+Write-Host "[smoke] Export RBAC spec..."
+& "$PSScriptRoot\specs\export_rbac.ps1"
+Write-Host "[smoke] RBAC quick test..."
+& "$PSScriptRoot\tests\spec_rbac_permissions.ps1"
+
 Write-Host "[smoke] OK"
 Exit 0

--- a/PS1/specs/export_rbac.ps1
+++ b/PS1/specs/export_rbac.ps1
@@ -1,0 +1,71 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$root   = Resolve-Path "$PSScriptRoot\..\.."
+$specDir= Join-Path $root "docs\specs"
+New-Item -ItemType Directory -Force -Path $specDir | Out-Null
+
+# Define matrix in memory
+$rows = @(
+  @{resource="employees"; action="read:list"   ; admin="allow"; manager="allow"; employe="allow"},
+  @{resource="employees"; action="read:detail" ; admin="allow"; manager="allow"; employe="allow"},
+  @{resource="employees"; action="create"     ; admin="allow"; manager="allow"; employe="deny" },
+  @{resource="employees"; action="update"     ; admin="allow"; manager="allow"; employe="deny" },
+  @{resource="employees"; action="delete"     ; admin="allow"; manager="deny" ; employe="deny" },
+  @{resource="org_units"; action="read:list"  ; admin="allow"; manager="allow"; employe="allow"},
+  @{resource="org_units"; action="read:detail"; admin="allow"; manager="allow"; employe="allow"},
+  @{resource="org_units"; action="create"     ; admin="allow"; manager="deny" ; employe="deny" },
+  @{resource="org_units"; action="update"     ; admin="allow"; manager="deny" ; employe="deny" },
+  @{resource="org_units"; action="delete"     ; admin="allow"; manager="deny" ; employe="deny" },
+  @{resource="schedules"; action="read:list"  ; admin="allow"; manager="allow"; employe="allow"},
+  @{resource="schedules"; action="read:detail"; admin="allow"; manager="allow"; employe="allow"},
+  @{resource="schedules"; action="create"     ; admin="allow"; manager="allow"; employe="deny" },
+  @{resource="schedules"; action="update"     ; admin="allow"; manager="allow"; employe="deny" },
+  @{resource="schedules"; action="delete"     ; admin="allow"; manager="deny" ; employe="deny" }
+)
+
+# Write CSV
+$csvPath = Join-Path $specDir "rbac_v1.csv"
+"resource,action,admin,manager,employe" | Set-Content -LiteralPath $csvPath -Encoding UTF8
+foreach ($r in $rows) {
+  "$($r.resource),$($r.action),$($r.admin),$($r.manager),$($r.employe)" | Add-Content -LiteralPath $csvPath -Encoding UTF8
+}
+
+# Write Markdown table
+$mdPath = Join-Path $specDir "rbac_v1.md"
+$md = @()
+$md += "# Matrice RBAC v1"
+$md += ""
+$md += "Version: 1.0.0"
+$md += "Objet: definir les droits initiaux par role (admin, manager, employe) sur les ressources critiques court terme."
+$md += ""
+$md += "## Ressources cibles (v1)"
+$md += "- employees"
+$md += "- org_units (services/equipes)"
+$md += "- schedules"
+$md += ""
+$md += "## Actions standard"
+$md += "- read:list, read:detail, create, update, delete"
+$md += ""
+$md += "## Regles v1"
+$md += "- admin: tous les droits sur toutes les ressources."
+$md += "- manager: lecture sur tout, creation/update limitees au perimetre d'equipe (politique precisee plus tard), pas de delete sur org_units; delete employees restreint (v2)."
+$md += "- employe: lecture de base (self + donnees publiques), pas de create/update/delete sauf operations personnelles futures (v2)."
+$md += ""
+$md += "Voir tableau CSV/Markdown pour la matrice de verite."
+$md += ""
+$md += "### Tableau (extrait aligne au CSV)"
+$md += "resource | action      | admin | manager | employe"
+foreach ($r in $rows) {
+  $md += ([string]::Format("{0}| {1,-11} | {2,-5} | {3,-7} | {4,-7}",$r.resource,$r.action,$r.admin,$r.manager,$r.employe))
+}
+$md += ""
+$md += "Notes:"
+$md += '- Les contraintes "perimetre d''equipe" seront definies applicativement a l''etape backend correspondante.'
+$md += '- Une granularite par champ (field-level) sera traitee en extension (v2).'
+$mdText = ($md -join [Environment]::NewLine)
+Set-Content -LiteralPath $mdPath -Value $mdText -Encoding UTF8
+
+Write-Host "export_rbac: wrote $csvPath and $mdPath"
+Exit 0
+

--- a/PS1/test_all.ps1
+++ b/PS1/test_all.ps1
@@ -16,5 +16,10 @@ Write-Host "[test_all] Exporting orgchart spec..."
 Write-Host "[test_all] Running org hierarchy tests..."
 & "$PSScriptRoot\tests\spec_org_hierarchy.ps1"
 
+Write-Host "[test_all] Exporting RBAC spec..."
+& "$PSScriptRoot\specs\export_rbac.ps1"
+Write-Host "[test_all] Running RBAC tests..."
+& "$PSScriptRoot\tests\spec_rbac_permissions.ps1"
+
 Write-Host "[test_all] DONE"
 Exit 0

--- a/PS1/tests/spec_rbac_permissions.ps1
+++ b/PS1/tests/spec_rbac_permissions.ps1
@@ -1,0 +1,60 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$root    = Resolve-Path "$PSScriptRoot\..\.."
+$csvPath = Join-Path $root "docs\specs\rbac_v1.csv"
+if (-not (Test-Path $csvPath)) {
+  Write-Error "spec_rbac: missing $csvPath. Run PS1\specs\export_rbac.ps1 first."
+}
+
+# Load CSV into objects
+$lines = Get-Content -LiteralPath $csvPath
+if ($lines.Count -lt 2) { Write-Error "spec_rbac: CSV seems empty." }
+$header = $lines[0].Split(",")
+$records = @()
+for ($i=1; $i -lt $lines.Count; $i++) {
+  $cols = $lines[$i].Split(",")
+  $obj = [ordered]@{}
+  for ($c=0; $c -lt $header.Length; $c++) {
+    $obj[$header[$c]] = $cols[$c]
+  }
+  $records += [pscustomobject]$obj
+}
+
+function Get-Decision {
+  param([string]$resource,[string]$action,[string]$role)
+  $row = $records | Where-Object { $_.resource -eq $resource -and $_.action -eq $action }
+  if (-not $row) { return "deny" }
+  switch ($role) {
+    "admin"   { return $row.admin }
+    "manager" { return $row.manager }
+    "employe" { return $row.employe }
+    default   { return "deny" }
+  }
+}
+
+# Test OK: admin has all designated rights
+$okPairs = @(
+  @("employees","create"),
+  @("employees","delete"),
+  @("org_units","delete"),
+  @("schedules","update")
+)
+foreach ($p in $okPairs) {
+  $d = Get-Decision -resource $p[0] -action $p[1] -role "admin"
+  if ($d -ne "allow") {
+    Write-Host "[KO] expected admin allow on $($p[0])/$($p[1]) but got $d" ; exit 1
+  }
+}
+Write-Host "[OK] admin has all designated rights"
+
+# Test KO: employe cannot delete another employee
+$decision = Get-Decision -resource "employees" -action "delete" -role "employe"
+if ($decision -ne "deny") {
+  Write-Host "[KO] expected employe deny on employees/delete, got $decision" ; exit 1
+}
+Write-Host "[OK] employe denied on employees/delete"
+
+Write-Host "spec rbac tests: PASS"
+Exit 0
+

--- a/PS1/tools/docs_guard.ps1
+++ b/PS1/tools/docs_guard.ps1
@@ -8,6 +8,8 @@ $specMdEmp = "docs/specs/employee_v1.md"
 $specJsonEmp = "docs/specs/employee_v1.json"
 $specMdOrg = "docs/specs/orgchart_v1.md"
 $specJsonOrg = "docs/specs/orgchart_v1.json"
+$specMdRBAC = "docs/specs/rbac_v1.md"
+$specCsvRBAC= "docs/specs/rbac_v1.csv"
 
 if (-not (Test-Path $readme)) { Write-Error "docs_guard: README.md missing" }
 if (-not (Test-Path $index)) { Write-Error "docs_guard: docs/roadmap/index.md missing" }
@@ -33,6 +35,16 @@ if ($indexText -notmatch "Organigramme v1") {
 }
 if (-not (Test-Path (Join-Path $root $specMdOrg))) { Write-Error "docs_guard: $specMdOrg missing" }
 if (-not (Test-Path (Join-Path $root $specJsonOrg))) { Write-Error "docs_guard: $specJsonOrg missing" }
+
+# RBAC v1 checks
+if ($readmeText -notmatch [regex]::Escape($specMdRBAC)) {
+  Write-Error "docs_guard: README must reference $specMdRBAC"
+}
+if ($indexText -notmatch "RBAC v1") {
+  Write-Error "docs_guard: index.md must mention RBAC v1"
+}
+if (-not (Test-Path (Join-Path $root $specMdRBAC))) { Write-Error "docs_guard: $specMdRBAC missing" }
+if (-not (Test-Path (Join-Path $root $specCsvRBAC))) { Write-Error "docs_guard: $specCsvRBAC missing" }
 
 Write-Host "docs_guard: OK"
 Exit 0

--- a/README.md
+++ b/README.md
@@ -59,6 +59,28 @@ pwsh -NoLogo -NoProfile -File PS1\test_all.ps1
 
 ```
 
+## RBAC v1 (Etape 3)
+- Specs: `docs/specs/rbac_v1.md` et CSV `docs/specs/rbac_v1.csv`.
+- Export (regenerer):
+```
+
+pwsh -NoLogo -NoProfile -File PS1\specs\export_rbac.ps1
+
+```
+- Tests:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\tests\spec_rbac_permissions.ps1
+
+```
+- Packs rapides:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\smoke.ps1
+pwsh -NoLogo -NoProfile -File PS1\test_all.ps1
+
+```
+
 ## Scripts
 - `PS1\dev_up.ps1` : mise en route locale (etape 0: no-op).
 - `PS1\test_all.ps1` : lance le garde-fou de la roadmap.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -9,6 +9,7 @@ Chaque etape contient: Titre, Objectif, Livrables, Scripts, Tests, CI Gates, Acc
 - **roadmap_01-10.md (Actif)** : RH de base & planification (1-10) — Etapes detaillees (specs, tests, criteres).
   - Etape 1 - Gestion des employes: spec Employe v1 -> docs/specs/employee_v1.md (v1.0.0).
   - Etape 2 - Organigramme v1: voir docs/specs/orgchart_v1.md (v1.0.0). Contraintes: pas d'auto-reference, pas de cycles, N subordonnes autorises.
+  - Etape 3 - Roles et permissions (RBAC v1): voir docs/specs/rbac_v1.md (v1.0.0). Matrice CSV docs/specs/rbac_v1.csv.
 - roadmap_11-20.md : RH de base & planification (11-20)
 - roadmap_21-30.md : Conges, absences, temps (21-30)
 - roadmap_31-40.md : Conges, absences, temps (31-40)

--- a/docs/specs/rbac_v1.csv
+++ b/docs/specs/rbac_v1.csv
@@ -1,0 +1,16 @@
+resource,action,admin,manager,employe
+employees,read:list,allow,allow,allow
+employees,read:detail,allow,allow,allow
+employees,create,allow,allow,deny
+employees,update,allow,allow,deny
+employees,delete,allow,deny,deny
+org_units,read:list,allow,allow,allow
+org_units,read:detail,allow,allow,allow
+org_units,create,allow,deny,deny
+org_units,update,allow,deny,deny
+org_units,delete,allow,deny,deny
+schedules,read:list,allow,allow,allow
+schedules,read:detail,allow,allow,allow
+schedules,create,allow,allow,deny
+schedules,update,allow,allow,deny
+schedules,delete,allow,deny,deny

--- a/docs/specs/rbac_v1.md
+++ b/docs/specs/rbac_v1.md
@@ -1,0 +1,41 @@
+# Matrice RBAC v1
+
+Version: 1.0.0
+Objet: definir les droits initiaux par role (admin, manager, employe) sur les ressources critiques court terme.
+
+## Ressources cibles (v1)
+- employees
+- org_units (services/equipes)
+- schedules
+
+## Actions standard
+- read:list, read:detail, create, update, delete
+
+## Regles v1
+- admin: tous les droits sur toutes les ressources.
+- manager: lecture sur tout, creation/update limitees au perimetre d'equipe (politique precisee plus tard), pas de delete sur org_units; delete employees restreint (v2).
+- employe: lecture de base (self + donnees publiques), pas de create/update/delete sauf operations personnelles futures (v2).
+
+Voir tableau CSV/Markdown pour la matrice de verite.
+
+### Tableau (extrait aligne au CSV)
+resource | action      | admin | manager | employe
+employees| read:list   | allow | allow   | allow  
+employees| read:detail | allow | allow   | allow  
+employees| create      | allow | allow   | deny   
+employees| update      | allow | allow   | deny   
+employees| delete      | allow | deny    | deny   
+org_units| read:list   | allow | allow   | allow  
+org_units| read:detail | allow | allow   | allow  
+org_units| create      | allow | deny    | deny   
+org_units| update      | allow | deny    | deny   
+org_units| delete      | allow | deny    | deny   
+schedules| read:list   | allow | allow   | allow  
+schedules| read:detail | allow | allow   | allow  
+schedules| create      | allow | allow   | deny   
+schedules| update      | allow | allow   | deny   
+schedules| delete      | allow | deny    | deny   
+
+Notes:
+- Les contraintes "perimetre d'equipe" seront definies applicativement a l'etape backend correspondante.
+- Une granularite par champ (field-level) sera traitee en extension (v2).


### PR DESCRIPTION
## Summary
- add RBAC v1 matrix specs and export script
- guard docs for RBAC references
- smoke and test_all now cover RBAC

## Testing
- `pwsh -NoLogo -NoProfile -File PS1/specs/export_rbac.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/tests/spec_rbac_permissions.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/tools/docs_guard.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/smoke.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/test_all.ps1`


------
https://chatgpt.com/codex/tasks/task_e_68b76ab74c4483308a1dbf0358bdea56