### PR TITLE
step-4: auth v1 spec + export + password policy tests + docs updates

### DIFF
--- a/PS1/smoke.ps1
+++ b/PS1/smoke.ps1
@@ -6,13 +6,11 @@ Write-Host "[smoke] Roadmap quick check..."
 
 Write-Host "[smoke] Export employee spec..."
 & "$PSScriptRoot\specs\export_employe.ps1"
-
 Write-Host "[smoke] Email regex quick test..."
 & "$PSScriptRoot\tests\spec_employee_email_regex.ps1"
 
 Write-Host "[smoke] Export orgchart spec..."
 & "$PSScriptRoot\specs\export_org.ps1"
-
 Write-Host "[smoke] Org hierarchy quick test..."
 & "$PSScriptRoot\tests\spec_org_hierarchy.ps1"
 
@@ -20,6 +18,11 @@ Write-Host "[smoke] Export RBAC spec..."
 & "$PSScriptRoot\specs\export_rbac.ps1"
 Write-Host "[smoke] RBAC quick test..."
 & "$PSScriptRoot\tests\spec_rbac_permissions.ps1"
+
+Write-Host "[smoke] Export auth spec..."
+& "$PSScriptRoot\specs\export_auth.ps1"
+Write-Host "[smoke] Password policy quick test..."
+& "$PSScriptRoot\tests\spec_auth_password_policy.ps1"
 
 Write-Host "[smoke] OK"
 Exit 0

--- a/PS1/specs/export_auth.ps1
+++ b/PS1/specs/export_auth.ps1
@@ -1,0 +1,70 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$root = Resolve-Path "$PSScriptRoot\..\.."
+$specDir = Join-Path $root "docs\specs"
+New-Item -ItemType Directory -Force -Path $specDir | Out-Null
+
+$mdPath = Join-Path $specDir "auth_v1.md"
+$md = @'
+# Spec - Auth v1
+
+Version: 1.0.0
+Objet: definir la strategie d’authentification (MDP, hashing), la politique MDP, le verrouillage, les erreurs FR et les ouvertures SSO/OIDC futures.
+
+## Portee v1
+- Auth locale par mot de passe (username/email + password).
+- Hashing recommande: Argon2id (prioritaire) ou Bcrypt comme fallback (details d’impl. a l’etape backend).
+- Sessions/JWT seront definis dans un lot ulterieur.
+
+## Politique de mot de passe (v1)
+- Longueur minimale: 12 caracteres.
+- Doit contenir AU MOINS: 1 majuscule [A-Z], 1 minuscule [a-z], 1 chiffre [0-9], 1 special parmi !@#$%^&*()_+-=[]{};:'",.<>/?`~\
+- Interdits: espaces en debut/fin; mot de passe present dans la liste noire (ex: "password", "123456", "qwerty", "azerty").
+- Exemple OK: `Securite2025!Alpha`
+- Exemple KO: `short1!` (trop court)
+
+## Hashing (orientations)
+- Argon2id (recommande): params initiaux cibles
+  - memory_cost ~ 64-128 MB
+  - time_cost ~ 2-3
+  - parallelism ~ 2
+- Bcrypt (fallback): cost (work factor) 12-14
+- Stocker egalement: algorithme, params, sel, hash, date de rotation. Rotation envisagee par politique.
+
+## Verrouillage / Throttling
+- 5 tentatives KO sur 15 minutes -> verrouillage 15 minutes (HTTP 423 Locked).
+- Compteur de tentatives remis a zero apres succes ou apres delai.
+- Backoff progressif en option pour brute-force distribue.
+
+## Messages d’erreur (FR)
+- 400 Bad Request: "Requete invalide."
+- 401 Unauthorized: "Identifiants invalides."
+- 403 Forbidden: "Acces refuse."
+- 409 Conflict: "Conflit sur la ressource."
+- 422 Unprocessable Entity: "Donnees non valides."
+- 423 Locked: "Compte verrouille temporairement suite a plusieurs tentatives infructueuses."
+- 429 Too Many Requests: "Trop de tentatives. Veuillez reessayer plus tard."
+- 500 Internal Server Error: "Erreur interne."
+
+## Flux
+- POST /auth/login: credentials -> tokens/sessions (a definir), verifie compteur, renvoie 401 ou 423 selon etat.
+- POST /auth/logout: invalide la session/token (a definir).
+- POST /auth/reset-request: demande reset (email).
+- POST /auth/reset-confirm: applique nouveau MDP (valide politique).
+
+## SSO/OIDC (v2+)
+- Support futur OIDC (Azure AD, Google Workspace, etc.), mapping roles/RBAC.
+
+## Journalisation minimale
+- Log securise: request_id, user_id (si connu), evenement (login_ok, login_ko, locked), horodatage UTC, ip_tronquee.
+
+## Acceptation
+- Politique MDP testable (OK/KO).
+- Erreurs FR listees et codes HTTP associes.
+- Verrouillage precise (seuil et delai) documente.
+'@
+Set-Content -LiteralPath $mdPath -Value $md -Encoding UTF8
+
+Write-Host "export_auth: wrote $mdPath"
+Exit 0

--- a/PS1/test_all.ps1
+++ b/PS1/test_all.ps1
@@ -6,13 +6,11 @@ Write-Host "[test_all] Running roadmap guard..."
 
 Write-Host "[test_all] Exporting employee spec..."
 & "$PSScriptRoot\specs\export_employe.ps1"
-
 Write-Host "[test_all] Running spec email regex tests..."
 & "$PSScriptRoot\tests\spec_employee_email_regex.ps1"
 
 Write-Host "[test_all] Exporting orgchart spec..."
 & "$PSScriptRoot\specs\export_org.ps1"
-
 Write-Host "[test_all] Running org hierarchy tests..."
 & "$PSScriptRoot\tests\spec_org_hierarchy.ps1"
 
@@ -20,6 +18,11 @@ Write-Host "[test_all] Exporting RBAC spec..."
 & "$PSScriptRoot\specs\export_rbac.ps1"
 Write-Host "[test_all] Running RBAC tests..."
 & "$PSScriptRoot\tests\spec_rbac_permissions.ps1"
+
+Write-Host "[test_all] Exporting auth spec..."
+& "$PSScriptRoot\specs\export_auth.ps1"
+Write-Host "[test_all] Running password policy tests..."
+& "$PSScriptRoot\tests\spec_auth_password_policy.ps1"
 
 Write-Host "[test_all] DONE"
 Exit 0

--- a/PS1/tests/spec_auth_password_policy.ps1
+++ b/PS1/tests/spec_auth_password_policy.ps1
@@ -1,0 +1,45 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+# Politique MDP (miroir de docs/specs/auth_v1.md)
+$MinLen = 12
+$reUpper = '[A-Z]'
+$reLower = '[a-z]'
+$reDigit = '[0-9]'
+$reSpec  = '[!@#$%^&*()_+\-=\[\]{};:\'"",.<>\/\?`~\\]'
+$blacklist = @("password","123456","qwerty","azerty")
+
+function Test-Password {
+  param([Parameter(Mandatory=$true)][string]$Pwd)
+  if ([string]::IsNullOrWhiteSpace($Pwd)) { return $false }
+  if ($Pwd.StartsWith(" ") -or $Pwd.EndsWith(" ")) { return $false }
+  if ($Pwd.Length -lt $MinLen) { return $false }
+  if ($Pwd -notmatch $reUpper) { return $false }
+  if ($Pwd -notmatch $reLower) { return $false }
+  if ($Pwd -notmatch $reDigit) { return $false }
+  if ($Pwd -notmatch $reSpec)  { return $false }
+  $lower = $Pwd.ToLowerInvariant()
+  foreach ($b in $blacklist) {
+    if ($lower -like "*$b*") { return $false }
+  }
+  return $true
+}
+
+# 1 OK: mot de passe conforme
+$ok = "Securite2025!Alpha"
+if (-not (Test-Password $ok)) {
+  Write-Host "[KO] expected OK for password: $ok" ; exit 1
+} else {
+  Write-Host "[OK] valid password accepted"
+}
+
+# 1 KO: trop court
+$ko = "short1!"
+if (Test-Password $ko) {
+  Write-Host "[KO] expected KO for too short password: $ko" ; exit 1
+} else {
+  Write-Host "[OK] short password rejected (as expected)"
+}
+
+Write-Host "spec auth password policy tests: PASS"
+Exit 0

--- a/PS1/tools/docs_guard.ps1
+++ b/PS1/tools/docs_guard.ps1
@@ -10,6 +10,7 @@ $specMdOrg = "docs/specs/orgchart_v1.md"
 $specJsonOrg = "docs/specs/orgchart_v1.json"
 $specMdRBAC = "docs/specs/rbac_v1.md"
 $specCsvRBAC= "docs/specs/rbac_v1.csv"
+$specMdAuth = "docs/specs/auth_v1.md"
 
 if (-not (Test-Path $readme)) { Write-Error "docs_guard: README.md missing" }
 if (-not (Test-Path $index)) { Write-Error "docs_guard: docs/roadmap/index.md missing" }
@@ -45,6 +46,15 @@ if ($indexText -notmatch "RBAC v1") {
 }
 if (-not (Test-Path (Join-Path $root $specMdRBAC))) { Write-Error "docs_guard: $specMdRBAC missing" }
 if (-not (Test-Path (Join-Path $root $specCsvRBAC))) { Write-Error "docs_guard: $specCsvRBAC missing" }
+
+# Auth v1 checks
+if ($readmeText -notmatch [regex]::Escape($specMdAuth)) {
+  Write-Error "docs_guard: README must reference $specMdAuth"
+}
+if ($indexText -notmatch "Auth v1") {
+  Write-Error "docs_guard: index.md must mention Auth v1"
+}
+if (-not (Test-Path (Join-Path $root $specMdAuth))) { Write-Error "docs_guard: $specMdAuth missing" }
 
 Write-Host "docs_guard: OK"
 Exit 0

--- a/README.md
+++ b/README.md
@@ -81,6 +81,28 @@ pwsh -NoLogo -NoProfile -File PS1\test_all.ps1
 
 ```
 
+## Auth v1 (Etape 4)
+- Spec: `docs/specs/auth_v1.md` (v1.0.0).
+- Export:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\specs\export_auth.ps1
+
+```
+- Tests (politique MDP):
+```
+
+pwsh -NoLogo -NoProfile -File PS1\tests\spec_auth_password_policy.ps1
+
+```
+- Packs rapides:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\smoke.ps1
+pwsh -NoLogo -NoProfile -File PS1\test_all.ps1
+
+```
+
 ## Scripts
 - `PS1\dev_up.ps1` : mise en route locale (etape 0: no-op).
 - `PS1\test_all.ps1` : lance le garde-fou de la roadmap.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -10,6 +10,7 @@ Chaque etape contient: Titre, Objectif, Livrables, Scripts, Tests, CI Gates, Acc
   - Etape 1 - Gestion des employes: spec Employe v1 -> docs/specs/employee_v1.md (v1.0.0).
   - Etape 2 - Organigramme v1: voir docs/specs/orgchart_v1.md (v1.0.0). Contraintes: pas d'auto-reference, pas de cycles, N subordonnes autorises.
   - Etape 3 - Roles et permissions (RBAC v1): voir docs/specs/rbac_v1.md (v1.0.0). Matrice CSV docs/specs/rbac_v1.csv.
+  - Etape 4 - Authentification: voir `docs/specs/auth_v1.md` (v1.0.0). Politique MDP 12+, verrous 5/15 min, messages FR.
 - roadmap_11-20.md : RH de base & planification (11-20)
 - roadmap_21-30.md : Conges, absences, temps (21-30)
 - roadmap_31-40.md : Conges, absences, temps (31-40)

--- a/docs/specs/auth_v1.md
+++ b/docs/specs/auth_v1.md
@@ -1,0 +1,57 @@
+# Spec - Auth v1
+
+Version: 1.0.0
+Objet: definir la strategie d’authentification (MDP, hashing), la politique MDP, le verrouillage, les erreurs FR et les ouvertures SSO/OIDC futures.
+
+## Portee v1
+- Auth locale par mot de passe (username/email + password).
+- Hashing recommande: Argon2id (prioritaire) ou Bcrypt comme fallback (details d’impl. a l’etape backend).
+- Sessions/JWT seront definis dans un lot ulterieur.
+
+## Politique de mot de passe (v1)
+- Longueur minimale: 12 caracteres.
+- Doit contenir AU MOINS: 1 majuscule [A-Z], 1 minuscule [a-z], 1 chiffre [0-9], 1 special parmi !@#$%^&*()_+-=[]{};:'",.<>/?`~\
+- Interdits: espaces en debut/fin; mot de passe present dans la liste noire (ex: "password", "123456", "qwerty", "azerty").
+- Exemple OK: `Securite2025!Alpha`
+- Exemple KO: `short1!` (trop court)
+
+## Hashing (orientations)
+- Argon2id (recommande): params initiaux cibles
+  - memory_cost ~ 64-128 MB
+  - time_cost ~ 2-3
+  - parallelism ~ 2
+- Bcrypt (fallback): cost (work factor) 12-14
+- Stocker egalement: algorithme, params, sel, hash, date de rotation. Rotation envisagee par politique.
+
+## Verrouillage / Throttling
+- 5 tentatives KO sur 15 minutes -> verrouillage 15 minutes (HTTP 423 Locked).
+- Compteur de tentatives remis a zero apres succes ou apres delai.
+- Backoff progressif en option pour brute-force distribue.
+
+## Messages d’erreur (FR)
+- 400 Bad Request: "Requete invalide."
+- 401 Unauthorized: "Identifiants invalides."
+- 403 Forbidden: "Acces refuse."
+- 409 Conflict: "Conflit sur la ressource."
+- 422 Unprocessable Entity: "Donnees non valides."
+- 423 Locked: "Compte verrouille temporairement suite a plusieurs tentatives infructueuses."
+- 429 Too Many Requests: "Trop de tentatives. Veuillez reessayer plus tard."
+- 500 Internal Server Error: "Erreur interne."
+
+## Flux
+- POST /auth/login: credentials -> tokens/sessions (a definir), verifie compteur, renvoie 401 ou 423 selon etat.
+- POST /auth/logout: invalide la session/token (a definir).
+- POST /auth/reset-request: demande reset (email).
+- POST /auth/reset-confirm: applique nouveau MDP (valide politique).
+
+## SSO/OIDC (v2+)
+- Support futur OIDC (Azure AD, Google Workspace, etc.), mapping roles/RBAC.
+
+## Journalisation minimale
+- Log securise: request_id, user_id (si connu), evenement (login_ok, login_ko, locked), horodatage UTC, ip_tronquee.
+
+## Acceptation
+- Politique MDP testable (OK/KO).
+- Erreurs FR listees et codes HTTP associes.
+- Verrouillage precise (seuil et delai) documente.
+


### PR DESCRIPTION
## Summary
- add Auth v1 spec detailing password policy, hashing, lockout, and error codes
- export script and PowerShell tests for password policy
- README and roadmap updated; docs_guard checks Auth v1 references

## Testing
- `pwsh -NoLogo -NoProfile -File PS1/specs/export_auth.ps1` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -File PS1/tests/spec_auth_password_policy.ps1` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -File PS1/tools/docs_guard.ps1` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -File PS1/smoke.ps1` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -File PS1/test_all.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b76caed98883309b17db9fe2adc274