### PR TITLE
fix(step-4): add Auth v1 to roadmap index + export specs in docs-guard

### DIFF
--- a/.github/workflows/docs-guard.yml
+++ b/.github/workflows/docs-guard.yml
@@ -9,10 +9,19 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Run docs guard
+      - name: Export specs (ensure up-to-date)
         shell: pwsh
         run: |
           $ErrorActionPreference = "Stop"
           Set-StrictMode -Version Latest
           ./PS1/specs/export_employe.ps1
+          ./PS1/specs/export_org.ps1
+          ./PS1/specs/export_rbac.ps1
+          ./PS1/specs/export_auth.ps1
+          ./PS1/specs/export_settings.ps1
+      - name: Run docs guard
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = "Stop"
+          Set-StrictMode -Version Latest
           ./PS1/tools/docs_guard.ps1

--- a/PS1/fixes/patch_index_auth.ps1
+++ b/PS1/fixes/patch_index_auth.ps1
@@ -1,0 +1,15 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+$root = Resolve-Path "$PSScriptRoot\..\.."
+$idx  = Join-Path $root "docs\roadmap\index.md"
+if (-not (Test-Path $idx)) { Write-Error "index.md introuvable" }
+$txt = Get-Content -Raw -LiteralPath $idx
+$line = "- Etape 4 - Authentification: voir `docs/specs/auth_v1.md` (v1.0.0). Politique MDP 12+, verrou 5/15 min, messages FR."
+if ($txt -notmatch "Etape 4 - Authentification") {
+  $txt = $txt.TrimEnd() + [Environment]::NewLine + $line + [Environment]::NewLine
+  Set-Content -LiteralPath $idx -Value $txt -Encoding UTF8
+  Write-Host "Ajout de la ligne Auth v1 dans index.md"
+} else {
+  Write-Host "La ligne Auth v1 est deja presente dans index.md"
+}
+Exit 0

--- a/README.md
+++ b/README.md
@@ -110,3 +110,4 @@ pwsh -NoLogo -NoProfile -File PS1\test_all.ps1
 
 ## CI
 - Workflow `roadmap-guard` sur Windows. Echec si la roadmap est incoherente.
+- Workflow `docs-guard` sur Windows. Exporte toutes les specs puis verifie la presence des references dans `docs/roadmap/index.md`.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -7,10 +7,11 @@ Chaque etape contient: Titre, Objectif, Livrables, Scripts, Tests, CI Gates, Acc
 
 ## Table des fichiers (10 etapes par fichier)
 - **roadmap_01-10.md (Actif)** : RH de base & planification (1-10) — Etapes detaillees (specs, tests, criteres).
-  - Etape 1 - Gestion des employes: spec Employe v1 -> docs/specs/employee_v1.md (v1.0.0).
-  - Etape 2 - Organigramme v1: voir docs/specs/orgchart_v1.md (v1.0.0). Contraintes: pas d'auto-reference, pas de cycles, N subordonnes autorises.
-  - Etape 3 - Roles et permissions (RBAC v1): voir docs/specs/rbac_v1.md (v1.0.0). Matrice CSV docs/specs/rbac_v1.csv.
-  - Etape 4 - Authentification: voir `docs/specs/auth_v1.md` (v1.0.0). Politique MDP 12+, verrous 5/15 min, messages FR.
+  - Etape 1 - Gestion des employes: voir `docs/specs/employee_v1.md` (v1.0.0).
+  - Etape 2 - Organigramme: voir `docs/specs/orgchart_v1.md` (v1.0.0).
+  - Etape 3 - Roles et permissions: voir `docs/specs/rbac_v1.md` (v1.0.0).
+  - Etape 4 - Authentification: voir `docs/specs/auth_v1.md` (v1.0.0). Politique MDP 12+, verrou 5/15 min, messages FR.
+  - Etape 5 - Parametres entreprise: voir `docs/specs/org_settings_v1.md` (v1.0.0).
 - roadmap_11-20.md : RH de base & planification (11-20)
 - roadmap_21-30.md : Conges, absences, temps (21-30)
 - roadmap_31-40.md : Conges, absences, temps (31-40)


### PR DESCRIPTION
## Summary
- ensure roadmap index references Auth v1 and company settings specs
- docs-guard exports all specs before verifying docs
- add helper script to patch Auth reference in index

## Testing
- `pwsh -NoLogo -NoProfile -File PS1/fixes/patch_index_auth.ps1` *(fails: command not found)*
- `apt-get install -y powershell` *(fails: Unable to locate package powershell)*
- `pwsh -NoLogo -NoProfile -File PS1/smoke.ps1` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -File PS1/test_all.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b76f17f4508330a41c8247f15d3b25