### PR TITLE
fix(ci): add PS1/specs/export_settings.ps1 to satisfy docs-guard workflow

### DIFF
--- a/PS1/specs/export_settings.ps1
+++ b/PS1/specs/export_settings.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$root = Resolve-Path "$PSScriptRoot\..\.."
+$specDir = Join-Path $root "docs\specs"
+New-Item -ItemType Directory -Force -Path $specDir | Out-Null
+
+$mdPath = Join-Path $specDir "org_settings_v1.md"
+$md = @'
+# Spec - Org Settings v1
+
+Version: 1.0.0
+(Contenu: structure multi-sites, timezone_default/devise_default/locale_default, formats date/heure/nombres, politiques RH. Validation TZ (IANA/UTC).)
+'@
+Set-Content -LiteralPath $mdPath -Value $md -Encoding UTF8
+
+Write-Host "export_settings: wrote $mdPath"
+Exit 0


### PR DESCRIPTION
## Summary
- add missing Org Settings v1 export script so docs-guard can run

## Testing
- `pwsh -NoLogo -NoProfile -File PS1\specs\export_settings.ps1` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -File PS1\smoke.ps1` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -File PS1\test_all.ps1` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b770aec37c8330a36d47fa9ebf7c23