### PR TITLE
step-5: org settings v1 spec + export + TZ tests + docs updates

### DIFF
--- a/PS1/smoke.ps1
+++ b/PS1/smoke.ps1
@@ -24,5 +24,10 @@ Write-Host "[smoke] Export auth spec..."
 Write-Host "[smoke] Password policy quick test..."
 & "$PSScriptRoot\tests\spec_auth_password_policy.ps1"
 
+Write-Host "[smoke] Export org settings spec..."
+& "$PSScriptRoot\specs\export_settings.ps1"
+Write-Host "[smoke] Org settings TZ quick test..."
+& "$PSScriptRoot\tests\spec_org_settings_tz.ps1"
+
 Write-Host "[smoke] OK"
 Exit 0

--- a/PS1/test_all.ps1
+++ b/PS1/test_all.ps1
@@ -24,5 +24,10 @@ Write-Host "[test_all] Exporting auth spec..."
 Write-Host "[test_all] Running password policy tests..."
 & "$PSScriptRoot\tests\spec_auth_password_policy.ps1"
 
+Write-Host "[test_all] Exporting org settings spec..."
+& "$PSScriptRoot\specs\export_settings.ps1"
+Write-Host "[test_all] Running org settings TZ tests..."
+& "$PSScriptRoot\tests\spec_org_settings_tz.ps1"
+
 Write-Host "[test_all] DONE"
 Exit 0

--- a/PS1/tests/spec_org_settings_tz.ps1
+++ b/PS1/tests/spec_org_settings_tz.ps1
@@ -1,0 +1,39 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+# Validator pragmatique pour TZ: accepte "UTC" ou quelques zones IANA courantes,
+# et permet d'etendre la liste plus tard (backend/DB).
+$AllowedIana = @(
+  "UTC",
+  "Europe/Paris",
+  "Indian/Reunion",
+  "America/New_York",
+  "Europe/London"
+)
+
+function Test-TimeZoneValid {
+  param([Parameter(Mandatory=$true)][string]$Tz)
+  if ([string]::IsNullOrWhiteSpace($Tz)) { return $false }
+  # Normaliser les espaces
+  $tzTrim = $Tz.Trim()
+  return ($AllowedIana -contains $tzTrim)
+}
+
+# 1 OK: TZ valide reconnu
+$okTz = "Europe/Paris"
+if (-not (Test-TimeZoneValid $okTz)) {
+  Write-Host "[KO] expected valid TZ but rejected: $okTz" ; exit 1
+} else {
+  Write-Host "[OK] valid timezone accepted: $okTz"
+}
+
+# 1 KO: TZ inconnu -> erreur
+$koTz = "Mars/Phobos"
+if (Test-TimeZoneValid $koTz) {
+  Write-Host "[KO] expected invalid TZ but accepted: $koTz" ; exit 1
+} else {
+  Write-Host "[OK] invalid timezone rejected: $koTz"
+}
+
+Write-Host "spec org settings TZ tests: PASS"
+Exit 0

--- a/PS1/tools/docs_guard.ps1
+++ b/PS1/tools/docs_guard.ps1
@@ -11,6 +11,7 @@ $specJsonOrg = "docs/specs/orgchart_v1.json"
 $specMdRBAC = "docs/specs/rbac_v1.md"
 $specCsvRBAC= "docs/specs/rbac_v1.csv"
 $specMdAuth = "docs/specs/auth_v1.md"
+$specMdSettings = "docs/specs/org_settings_v1.md"
 
 if (-not (Test-Path $readme)) { Write-Error "docs_guard: README.md missing" }
 if (-not (Test-Path $index)) { Write-Error "docs_guard: docs/roadmap/index.md missing" }
@@ -55,6 +56,15 @@ if ($indexText -notmatch "Auth v1") {
   Write-Error "docs_guard: index.md must mention Auth v1"
 }
 if (-not (Test-Path (Join-Path $root $specMdAuth))) { Write-Error "docs_guard: $specMdAuth missing" }
+
+# Org Settings v1 checks
+if ($readmeText -notmatch [regex]::Escape($specMdSettings)) {
+  Write-Error "docs_guard: README must reference $specMdSettings"
+}
+if ($indexText -notmatch "Org Settings v1") {
+  Write-Error "docs_guard: index.md must mention Org Settings v1"
+}
+if (-not (Test-Path (Join-Path $root $specMdSettings))) { Write-Error "docs_guard: $specMdSettings missing" }
 
 Write-Host "docs_guard: OK"
 Exit 0

--- a/README.md
+++ b/README.md
@@ -103,6 +103,28 @@ pwsh -NoLogo -NoProfile -File PS1\test_all.ps1
 
 ```
 
+## Org Settings v1 (Etape 5)
+- Spec: `docs/specs/org_settings_v1.md` (v1.0.0).
+- Export:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\specs\export_settings.ps1
+
+```
+- Tests (TZ OK/KO):
+```
+
+pwsh -NoLogo -NoProfile -File PS1\tests\spec_org_settings_tz.ps1
+
+```
+- Packs rapides:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\smoke.ps1
+pwsh -NoLogo -NoProfile -File PS1\test_all.ps1
+
+```
+
 ## Scripts
 - `PS1\dev_up.ps1` : mise en route locale (etape 0: no-op).
 - `PS1\test_all.ps1` : lance le garde-fou de la roadmap.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -11,7 +11,7 @@ Chaque etape contient: Titre, Objectif, Livrables, Scripts, Tests, CI Gates, Acc
   - Etape 2 - Organigramme: voir `docs/specs/orgchart_v1.md` (v1.0.0).
   - Etape 3 - Roles et permissions: voir `docs/specs/rbac_v1.md` (v1.0.0).
   - Etape 4 - Authentification: voir `docs/specs/auth_v1.md` (v1.0.0). Politique MDP 12+, verrou 5/15 min, messages FR.
-  - Etape 5 - Parametres entreprise: voir `docs/specs/org_settings_v1.md` (v1.0.0).
+  - Etape 5 - Parametres entreprise: voir `docs/specs/org_settings_v1.md` (v1.0.0). Parametres critiques: timezone_default, devise_default, locale_default, formats.
 - roadmap_11-20.md : RH de base & planification (11-20)
 - roadmap_21-30.md : Conges, absences, temps (21-30)
 - roadmap_31-40.md : Conges, absences, temps (31-40)

--- a/docs/specs/org_settings_v1.md
+++ b/docs/specs/org_settings_v1.md
@@ -1,0 +1,67 @@
+# Spec - Org Settings v1
+
+Version: 1.0.0
+Objet: definir la structure de configuration multi-sites et les parametres critiques de l’organisation.
+
+## Portee v1
+- Multi-sites (organisation possede 1..N sites).
+- Parametres globaux (org) et specifiques (site).
+- Sans secret (identifiants/cles gerees ailleurs).
+
+## Modele (conceptuel)
+Organisation (root)
+- org_id: uuid
+- nom: string [2..120] (requis)
+- siret: string [14] FR optionnel (ou numero similaire selon pays)
+- timezone_default: string (IANA ou "UTC") (requis) ex: UTC, Europe/Paris, Indian/Reunion
+- devise_default: string (ISO 4217) ex: EUR, USD, GBP (requis)
+- locale_default: string (BCP 47) ex: fr-FR, en-US (requis)
+- formats:
+  - date: string (ex: yyyy-MM-dd)
+  - time: string (ex: HH:mm)
+  - number: string (ex: 1 234,56)
+- politiques_rh:
+  - semaine_1er_jour: int (1=lundi, 7=dimanche)
+  - conges_arrondi_heures: bool
+  - jours_feries_strategy: string (ex: FR-national, custom)
+
+Sites (1..N)
+- site_id: uuid
+- code: string [2..30] (unique org)
+- nom: string [2..120]
+- adresse:
+  - ligne1, ligne2?, code_postal, ville, pays
+- timezone: string (IANA/UTC) (optionnel; defaut = timezone_default)
+- devise: string (ISO 4217) (optionnel; defaut = devise_default)
+- locale: string (BCP 47) (optionnel; defaut = locale_default)
+
+## Parametres critiques au lancement
+- timezone_default (obligatoire)
+- devise_default (ISO 4217)
+- locale_default (BCP 47)
+- formats (date/time/number)
+- semaine_1er_jour
+
+## Conventions
+- Stockage des timestamps en UTC (DB); affichage converti par site/locale.
+- Validation TZ: IANA (ex: Europe/Paris, Indian/Reunion) ou "UTC".
+- Devise: ISO 4217 (EUR, USD, GBP, ...).
+- Locale: BCP 47 (fr-FR, en-US, ...).
+
+## Exemples
+Organisation:
+- nom: Orga Demo
+- siret: 12345678901234
+- timezone_default: Europe/Paris
+- devise_default: EUR
+- locale_default: fr-FR
+
+Site Bobino:
+- code: BOBINO
+- timezone: Europe/Paris
+- devise: EUR
+- locale: fr-FR
+
+## Acceptation
+- Parametres minimaux identifies, valides et documentes (sans secret).
+- Test OK/KO sur fuseaux horaires.


### PR DESCRIPTION
## Summary
- document critical multi-site organization settings in new spec `org_settings_v1.md`
- add PowerShell export script and timezone validation tests
- integrate org settings references into docs guard, smoke, test_all, roadmap, and README

## Testing
- `pwsh -NoLogo -NoProfile -File PS1/specs/export_settings.ps1` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -File PS1/tests/spec_org_settings_tz.ps1` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -File PS1/smoke.ps1` *(fails: command not found)*
- `pwsh -NoLogo -NoProfile -File PS1/test_all.ps1` *(fails: command not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b7759b86088330a2058d8660e26201