### PR TITLE
step-6: notifications v1 spec + export + render tests + docs updates

### DIFF
--- a/PS1/smoke.ps1
+++ b/PS1/smoke.ps1
@@ -29,5 +29,10 @@ Write-Host "[smoke] Export org settings spec..."
 Write-Host "[smoke] Org settings TZ quick test..."
 & "$PSScriptRoot\tests\spec_org_settings_tz.ps1"
 
+Write-Host "[smoke] Export notifications spec..."
+& "$PSScriptRoot\specs\export_notifications.ps1"
+Write-Host "[smoke] Notifications render quick test..."
+& "$PSScriptRoot\tests\spec_notifications_render.ps1"
+
 Write-Host "[smoke] OK"
 Exit 0

--- a/PS1/specs/export_notifications.ps1
+++ b/PS1/specs/export_notifications.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$root = Resolve-Path "$PSScriptRoot\..\.."
+$specDir = Join-Path $root "docs\specs"
+New-Item -ItemType Directory -Force -Path $specDir | Out-Null
+
+$mdPath = Join-Path $specDir "notifications_v1.md"
+$md = @'
+# Spec - Notifications v1
+
+Version: 1.0.0
+(Contenu: triggers employee.created, schedule.updated, auth.reset_requested; placeholders {{var}}; canaux email/in-app; regles de rendu/erreur.)
+'@
+Set-Content -LiteralPath $mdPath -Value $md -Encoding UTF8
+
+Write-Host "export_notifications: wrote $mdPath"
+Exit 0

--- a/PS1/test_all.ps1
+++ b/PS1/test_all.ps1
@@ -29,5 +29,10 @@ Write-Host "[test_all] Exporting org settings spec..."
 Write-Host "[test_all] Running org settings TZ tests..."
 & "$PSScriptRoot\tests\spec_org_settings_tz.ps1"
 
+Write-Host "[test_all] Exporting notifications spec..."
+& "$PSScriptRoot\specs\export_notifications.ps1"
+Write-Host "[test_all] Running notifications render tests..."
+& "$PSScriptRoot\tests\spec_notifications_render.ps1"
+
 Write-Host "[test_all] DONE"
 Exit 0

--- a/PS1/tests/spec_auth_password_policy.ps1
+++ b/PS1/tests/spec_auth_password_policy.ps1
@@ -6,7 +6,7 @@ $MinLen = 12
 $reUpper = '[A-Z]'
 $reLower = '[a-z]'
 $reDigit = '[0-9]'
-$reSpec  = '[!@#$%^&*()_+\-=\[\]{};:\'"",.<>\/\?`~\\]'
+$reSpec  = '[!@#$%^&*()_+\-=\[\]{};:''"",.<>\/\?`~\\]'
 $blacklist = @("password","123456","qwerty","azerty")
 
 function Test-Password {

--- a/PS1/tests/spec_notifications_render.ps1
+++ b/PS1/tests/spec_notifications_render.ps1
@@ -1,0 +1,73 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Get-TemplatePlaceholders {
+param([Parameter(Mandatory=$true)][string]$Template)
+# Match {{name}} with ASCII word chars, dots and underscores if needed
+$matches = [regex]::Matches($Template, "{{([A-Za-z0-9_\.]+)}}")
+$set = New-Object System.Collections.Generic.HashSet[string]
+foreach ($m in $matches) { [void]$set.Add($m.Groups[1].Value) }
+return ,$set
+}
+
+function Render-Template {
+param(
+  [Parameter(Mandatory=$true)][string]$Template,
+  [Parameter(Mandatory=$true)][hashtable]$Data
+)
+$placeholders = Get-TemplatePlaceholders -Template $Template
+# Validate presence
+foreach ($k in $placeholders) {
+  if (-not $Data.ContainsKey($k)) {
+    throw "Placeholder manquant: $k"
+  }
+}
+$out = $Template
+foreach ($k in $placeholders) {
+  $v = [string]$Data[$k]
+  $vEsc = $v -replace '\\','\\\\' -replace '\$','$$'
+  $out = $out -replace ("\{\{" + [regex]::Escape($k) + "\}\}"), $vEsc
+}
+return $out
+}
+
+# Template sample (employee.created)
+$templateOK = @"
+Bonjour {{employee_name}},
+Votre compte a ete cree avec l'adresse {{employee_email}} le {{created_at}}.
+"@
+
+# 1 OK: rendu avec toutes les variables
+$dataOK = @{
+employee_name = "Alice Martin"
+employee_email = "alice.martin@example.com"
+created_at = "2025-09-03 10:00"
+}
+try {
+$rendered = Render-Template -Template $templateOK -Data $dataOK
+if ($rendered -notmatch "Alice Martin" -or $rendered -notmatch "alice.martin@example.com") {
+  Write-Host "[KO] rendu ne contient pas les valeurs attendues" ; exit 1
+}
+Write-Host "[OK] rendu template avec placeholders completes"
+} catch {
+Write-Host "[KO] exception inattendue: $($_.Exception.Message)" ; exit 1
+}
+
+# 1 KO: placeholder manquant
+$dataKO = @{
+employee_name = "Bob"
+# employee_email manquant
+created_at = "2025-09-03 10:00"
+}
+$failed = $false
+try {
+$null = Render-Template -Template $templateOK -Data $dataKO
+Write-Host "[KO] rendu aurait du echouer (placeholder manquant)" ; $failed = $true
+} catch {
+if ($_.Exception.Message -notmatch "Placeholder manquant: employee_email") {
+  Write-Host "[KO] message d'erreur inattendu: $($_.Exception.Message)" ; $failed = $true
+} else {
+  Write-Host "[OK] erreur claire sur placeholder manquant"
+}
+}
+if ($failed) { exit 1 } else { Write-Host "spec notifications render tests: PASS"; exit 0 }

--- a/PS1/tools/docs_guard.ps1
+++ b/PS1/tools/docs_guard.ps1
@@ -66,5 +66,17 @@ if ($indexText -notmatch "Org Settings v1") {
 }
 if (-not (Test-Path (Join-Path $root $specMdSettings))) { Write-Error "docs_guard: $specMdSettings missing" }
 
+$specMdNotif = "docs/specs/notifications_v1.md"
+
+if ($readmeText -notmatch [regex]::Escape($specMdNotif)) {
+Write-Error "docs_guard: README must reference $specMdNotif"
+}
+if ($indexText -notmatch "Notifications v1") {
+Write-Error "docs_guard: index.md must mention Notifications v1"
+}
+if (-not (Test-Path (Join-Path $root $specMdNotif))) {
+Write-Error "docs_guard: $specMdNotif missing"
+}
+
 Write-Host "docs_guard: OK"
 Exit 0

--- a/README.md
+++ b/README.md
@@ -125,6 +125,28 @@ pwsh -NoLogo -NoProfile -File PS1\test_all.ps1
 
 ```
 
+## Notifications v1 (Etape 6)
+- Spec: `docs/specs/notifications_v1.md` (v1.0.0).
+- Export:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\specs\export_notifications.ps1
+
+```
+- Tests (rendu de template):
+```
+
+pwsh -NoLogo -NoProfile -File PS1\tests\spec_notifications_render.ps1
+
+```
+- Packs rapides:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\smoke.ps1
+pwsh -NoLogo -NoProfile -File PS1\test_all.ps1
+
+```
+
 ## Scripts
 - `PS1\dev_up.ps1` : mise en route locale (etape 0: no-op).
 - `PS1\test_all.ps1` : lance le garde-fou de la roadmap.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -12,6 +12,7 @@ Chaque etape contient: Titre, Objectif, Livrables, Scripts, Tests, CI Gates, Acc
   - Etape 3 - Roles et permissions: voir `docs/specs/rbac_v1.md` (v1.0.0).
   - Etape 4 - Authentification: voir `docs/specs/auth_v1.md` (v1.0.0). Politique MDP 12+, verrou 5/15 min, messages FR.
   - Etape 5 - Parametres entreprise: voir `docs/specs/org_settings_v1.md` (v1.0.0). Parametres critiques: timezone_default, devise_default, locale_default, formats.
+  - Etape 6 - Notifications systeme: voir `docs/specs/notifications_v1.md` (v1.0.0). Triggers + templates (placeholders {{var}}).
 - roadmap_11-20.md : RH de base & planification (11-20)
 - roadmap_21-30.md : Conges, absences, temps (21-30)
 - roadmap_31-40.md : Conges, absences, temps (31-40)
@@ -38,6 +39,7 @@ Chaque etape contient: Titre, Objectif, Livrables, Scripts, Tests, CI Gates, Acc
 - [RBAC v1](../specs/rbac_v1.md)
 - [Auth v1](../specs/auth_v1.md)
 - [Org Settings v1](../specs/org_settings_v1.md)
+- [Notifications v1](../specs/notifications_v1.md)
 
 ## Rattachements aux themes de la source fournie
 - RH de base & planification: employes, organigramme, roles, auth, parametres, notifications, multilingue, champs personnalises, import/export, journalisation, plannings, disponibilites, conflits, auto-planification, sync calendrier, historique, multi-sites, creneaux speciaux, notifications planning, rapports planning.

--- a/docs/specs/notifications_v1.md
+++ b/docs/specs/notifications_v1.md
@@ -1,0 +1,56 @@
+# Spec - Notifications v1
+
+Version: 1.0.0
+Objet: definir les canaux, le catalogue de notifications et le format de template (placeholders) pour l'application.
+
+## Canaux (v1)
+- email (texte/HTML minimal plus tard)
+- in-app (centre de notifications)
+
+## Placeholders (format)
+- Syntaxe: `{{nom_placeholder}}` (ASCII). Sensible a la casse.
+- Regle: tout placeholder present dans le template DOIT etre fourni par le contexte de rendu, sinon erreur.
+
+## Catalogue de triggers (v1)
+- `employee.created` : lorsqu'un nouvel employe est cree.
+  - placeholders: `employee_name`, `employee_email`, `created_at`
+  - canal par defaut: email (manager + RH), in-app (RH)
+- `schedule.updated` : modification d'un planning.
+  - placeholders: `employee_name`, `schedule_period`, `updated_by`
+  - canal par defaut: in-app (employe + manager)
+- `auth.reset_requested` : demande de reinitialisation de mot de passe.
+  - placeholders: `reset_link`, `support_email`, `requested_at`
+  - canal par defaut: email (utilisateur cible)
+
+## Templates de reference (FR)
+- employee.created (email/texte):
+```
+
+Bonjour {{employee_name}},
+Votre compte a ete cree avec l'adresse {{employee_email}} le {{created_at}}.
+
+```
+- schedule.updated (in-app):
+```
+
+Planning mis a jour pour {{employee_name}} sur la periode {{schedule_period}} (par {{updated_by}}).
+
+```
+- auth.reset_requested (email/texte):
+```
+
+Vous avez demande la reinitialisation de votre mot de passe le {{requested_at}}.
+Lien: {{reset_link}} - Support: {{support_email}}
+
+```
+
+## Regles d'envoi (v1)
+- Pas de retry/SMTP dans ce lot.
+- Rendu du template: si un placeholder requis manque -> erreur explicite.
+- Journalisation: type trigger, destinataires, resultat (ok/erreur).
+
+## Acceptation
+- 1 OK: rendu reussi quand tous les placeholders sont fournis.
+- 1 KO: erreur claire si un placeholder manque.
+
+---


### PR DESCRIPTION
## Summary
- add Notifications v1 specification and PowerShell export script
- cover template rendering with OK/KO PowerShell tests
- wire docs_guard, smoke and test_all to include notifications

## Testing
- `pwsh -NoLogo -NoProfile -File PS1/specs/export_notifications.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/tests/spec_notifications_render.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/smoke.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/test_all.ps1`


------
https://chatgpt.com/codex/tasks/task_e_68b776db58908330b11d6ccd9118458e