### PR TITLE
ci: use preinstalled pwsh

### DIFF
--- a/.github/workflows/your-workflow.yml
+++ b/.github/workflows/your-workflow.yml
@@ -6,15 +6,14 @@ on:
     branches: [ main ]
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup PowerShell 7
-        uses: PowerShell/setup-pwsh@v2
-        with:
-          pwsh-version: '7.4.x'
+      - name: Check pwsh version
+        shell: pwsh
+        run: pwsh -v
 
-      - name: Run PS script
+      - name: Run init script
         shell: pwsh
         run: ./PS1/init_repo.ps1 -Verbose


### PR DESCRIPTION
## Summary
- drop PowerShell setup action and run on Ubuntu 24.04
- verify preinstalled pwsh and run init script

## Testing
- `pwsh -v` *(fails: command not found)*
- `sudo apt-get install -y powershell` *(fails: Unable to locate package powershell)*

------
https://chatgpt.com/codex/tasks/task_e_68b77dff884c8330b47e28072c8fd0d9