### PR TITLE
step-7: i18n v1 spec + export + policy tests (fallback/dup) + docs updates

### DIFF
--- a/PS1/smoke.ps1
+++ b/PS1/smoke.ps1
@@ -34,5 +34,9 @@ Write-Host "[smoke] Export notifications spec..."
 Write-Host "[smoke] Notifications render quick test..."
 & "$PSScriptRoot\tests\spec_notifications_render.ps1"
 
+Write-Host "[smoke] Export i18n..."
+& "$PSScriptRoot\specs\export_i18n.ps1"
+& "$PSScriptRoot\tests\spec_i18n_policy.ps1"
+
 Write-Host "[smoke] OK"
 Exit 0

--- a/PS1/specs/export_i18n.ps1
+++ b/PS1/specs/export_i18n.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$root   = Resolve-Path "$PSScriptRoot\..\.."
+$specDir= Join-Path $root "docs\specs"
+New-Item -ItemType Directory -Force -Path $specDir | Out-Null
+
+$mdPath = Join-Path $specDir "i18n_v1.md"
+$md = @'
+# Spec - i18n v1
+
+Version: 1.0.0
+(Contenu: FR/EN; cles "domaine.sousdomaine.element"; JSON par locale; fallback -> fr; duplication interdite; liste initiale de cles.)
+'@
+Set-Content -LiteralPath $mdPath -Value $md -Encoding UTF8
+
+Write-Host "export_i18n: wrote $mdPath"
+Exit 0

--- a/PS1/test_all.ps1
+++ b/PS1/test_all.ps1
@@ -34,5 +34,10 @@ Write-Host "[test_all] Exporting notifications spec..."
 Write-Host "[test_all] Running notifications render tests..."
 & "$PSScriptRoot\tests\spec_notifications_render.ps1"
 
+Write-Host "[test_all] Exporting i18n spec..."
+& "$PSScriptRoot\specs\export_i18n.ps1"
+Write-Host "[test_all] Running i18n policy tests..."
+& "$PSScriptRoot\tests\spec_i18n_policy.ps1"
+
 Write-Host "[test_all] DONE"
 Exit 0

--- a/PS1/tests/spec_i18n_policy.ps1
+++ b/PS1/tests/spec_i18n_policy.ps1
@@ -1,0 +1,49 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+# Mini-kv pour test (simule locales)
+$fr = @{
+  "auth.login.title" = "Connexion"
+  "auth.password.label" = "Mot de passe"
+  "menu.employees" = "Employes"
+  "employees.form.email.label" = "Email professionnel"
+  "employees.form.save" = "Enregistrer"
+}
+$en = @{
+  "auth.login.title" = "Sign in"
+  # "auth.password.label" manquante -> doit fallback FR
+  "menu.employees" = "Employees"
+  "employees.form.email.label" = "Work email"
+  "employees.form.save" = "Save"
+}
+
+function Get-I18n {
+  param(
+    [Parameter(Mandatory=$true)][string]$Key,
+    [Parameter(Mandatory=$true)][hashtable]$Primary,
+    [Parameter(Mandatory=$true)][hashtable]$Fallback
+  )
+  if ($Primary.ContainsKey($Key)) { return $Primary[$Key] }
+  if ($Fallback.ContainsKey($Key)) { return $Fallback[$Key] }
+  return $Key  # cle brute si absente partout
+}
+
+# 1) OK: fallback vers FR si manquant en EN
+$val = Get-I18n -Key "auth.password.label" -Primary $en -Fallback $fr
+if ($val -ne "Mot de passe") {
+  Write-Host "[KO] expected fallback FR, got: $val" ; exit 1
+} else {
+  Write-Host "[OK] fallback -> FR fonctionne"
+}
+
+# 2) KO: cle dupliquee signalee (on simule un chargement avec doublon)
+$keys = @("menu.employees","menu.employees","auth.login.title")
+$dups = @($keys | Group-Object | Where-Object { $_.Count -gt 1 } | Select-Object -ExpandProperty Name)
+if ($dups.Count -gt 0) {
+  Write-Host "[OK] duplication detectee: $($dups -join ', ')"
+} else {
+  Write-Host "[KO] duplication non detectee" ; exit 1
+}
+
+Write-Host "spec i18n policy tests: PASS"
+Exit 0

--- a/PS1/tools/docs_guard.ps1
+++ b/PS1/tools/docs_guard.ps1
@@ -78,5 +78,17 @@ if (-not (Test-Path (Join-Path $root $specMdNotif))) {
 Write-Error "docs_guard: $specMdNotif missing"
 }
 
+$specMdI18n = "docs/specs/i18n_v1.md"
+
+if ($readmeText -notmatch [regex]::Escape($specMdI18n)) {
+  Write-Error "docs_guard: README must reference $specMdI18n"
+}
+if ($indexText -notmatch "i18n v1") {
+  Write-Error "docs_guard: index.md must mention i18n v1"
+}
+if (-not (Test-Path (Join-Path $root $specMdI18n))) {
+  Write-Error "docs_guard: $specMdI18n missing"
+}
+
 Write-Host "docs_guard: OK"
 Exit 0

--- a/README.md
+++ b/README.md
@@ -147,6 +147,28 @@ pwsh -NoLogo -NoProfile -File PS1\test_all.ps1
 
 ```
 
+## i18n v1 (Etape 7)
+- Spec: `docs/specs/i18n_v1.md` (v1.0.0).
+- Export:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\specs\export_i18n.ps1
+
+```
+- Tests:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\tests\spec_i18n_policy.ps1
+
+```
+- Packs rapides:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\smoke.ps1
+pwsh -NoLogo -NoProfile -File PS1\test_all.ps1
+
+```
+
 ## Scripts
 - `PS1\dev_up.ps1` : mise en route locale (etape 0: no-op).
 - `PS1\test_all.ps1` : lance le garde-fou de la roadmap.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -13,6 +13,7 @@ Chaque etape contient: Titre, Objectif, Livrables, Scripts, Tests, CI Gates, Acc
   - Etape 4 - Authentification: voir `docs/specs/auth_v1.md` (v1.0.0). Politique MDP 12+, verrou 5/15 min, messages FR.
   - Etape 5 - Parametres entreprise: voir `docs/specs/org_settings_v1.md` (v1.0.0). Parametres critiques: timezone_default, devise_default, locale_default, formats.
   - Etape 6 - Notifications systeme: voir `docs/specs/notifications_v1.md` (v1.0.0). Triggers + templates (placeholders {{var}}).
+  - Etape 7 - Support multilingue (UI): voir `docs/specs/i18n_v1.md` (i18n v1.0.0). Fallback -> FR; cles `domaine.sousdomaine.element`.
 - roadmap_11-20.md : RH de base & planification (11-20)
 - roadmap_21-30.md : Conges, absences, temps (21-30)
 - roadmap_31-40.md : Conges, absences, temps (31-40)

--- a/docs/specs/i18n_v1.md
+++ b/docs/specs/i18n_v1.md
@@ -1,0 +1,40 @@
+# Spec - i18n v1
+
+Version: 1.0.0
+Objet: definir les langues cibles (FR, EN), la nomenclature des cles, le format de stockage et la politique de fallback.
+
+## Langues cibles (v1)
+- fr (par defaut)
+- en
+
+## Nomenclature des cles
+- Convention: `domaine.sousdomaine.element` (snake_case tolere, preferer lower + points)
+- Exemples:
+  - `auth.login.title`
+  - `menu.employees`
+  - `employees.form.email.label`
+  - `notifications.reset_requested.title`
+
+## Format de fichiers
+- Frontend: JSON par langue (un fichier par locale)
+  - `locales/fr.json`, `locales/en.json`
+- Backend (optionnel): JSON ou YAML; miroir des cles FE.
+
+## Politique de fallback
+- Locale active -> si cle absente, fallback vers `fr`.
+- Si cle absente en `fr`: journaliser l'absence et retourner la cle brute (pour debug).
+
+## Duplications de cles
+- Interdites. Le build/docs doit signaler toute duplication.
+
+## Liste initiale de cles (extrait)
+- `auth.login.title`: FR="Connexion", EN="Sign in"
+- `auth.password.label`: FR="Mot de passe", EN="Password"
+- `menu.employees`: FR="Employes", EN="Employees"
+- `employees.form.email.label`: FR="Email professionnel", EN="Work email"
+- `employees.form.save`: FR="Enregistrer", EN="Save"
+
+## Acceptation
+- Test OK: fallback vers FR si cle manque en EN.
+- Test KO: duplication de cle detectee.
+


### PR DESCRIPTION
## Summary
- document "i18n v1" spec with FR/EN locales, key naming and fallback rules
- add PowerShell export script and policy tests for fallback and duplicate detection
- wire i18n references into docs guard, roadmap index, smoke/test suites and README

## Testing
- `pwsh -NoLogo -NoProfile -File PS1/specs/export_i18n.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/tests/spec_i18n_policy.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/smoke.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/test_all.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/tools/docs_guard.ps1`


------
https://chatgpt.com/codex/tasks/task_e_68b77d2839e88330af5d5e12e78b4b77