### PR TITLE
step-8: custom fields v1 spec + export + validation tests + docs updates

### DIFF
--- a/.github/workflows/docs-guard.yml
+++ b/.github/workflows/docs-guard.yml
@@ -19,6 +19,9 @@ jobs:
           ./PS1/specs/export_rbac.ps1
           ./PS1/specs/export_auth.ps1
           ./PS1/specs/export_settings.ps1
+          ./PS1/specs/export_notifications.ps1
+          ./PS1/specs/export_i18n.ps1
+          ./PS1/specs/export_custom_fields.ps1
       - name: Run docs guard
         shell: pwsh
         run: |

--- a/PS1/smoke.ps1
+++ b/PS1/smoke.ps1
@@ -37,6 +37,8 @@ Write-Host "[smoke] Notifications render quick test..."
 Write-Host "[smoke] Export i18n..."
 & "$PSScriptRoot\specs\export_i18n.ps1"
 & "$PSScriptRoot\tests\spec_i18n_policy.ps1"
+& "$PSScriptRoot\specs\export_custom_fields.ps1"
+& "$PSScriptRoot\tests\spec_custom_fields_validate.ps1"
 
 Write-Host "[smoke] OK"
 Exit 0

--- a/PS1/specs/export_custom_fields.ps1
+++ b/PS1/specs/export_custom_fields.ps1
@@ -1,0 +1,18 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$root   = Resolve-Path "$PSScriptRoot\..\.."
+$specDir= Join-Path $root "docs\specs"
+New-Item -ItemType Directory -Force -Path $specDir | Out-Null
+
+$mdPath = Join-Path $specDir "custom_fields_v1.md"
+$md = @'
+# Spec - Custom Fields v1
+
+Version: 1.0.0
+(Contenu: scope employee; types string/int/date/enum; name unique par scope; validations par type; exemples FR.)
+'@
+Set-Content -LiteralPath $mdPath -Value $md -Encoding UTF8
+
+Write-Host "export_custom_fields: wrote $mdPath"
+Exit 0

--- a/PS1/test_all.ps1
+++ b/PS1/test_all.ps1
@@ -39,5 +39,10 @@ Write-Host "[test_all] Exporting i18n spec..."
 Write-Host "[test_all] Running i18n policy tests..."
 & "$PSScriptRoot\tests\spec_i18n_policy.ps1"
 
+Write-Host "[test_all] Exporting custom fields spec..."
+& "$PSScriptRoot\specs\export_custom_fields.ps1"
+Write-Host "[test_all] Running custom fields tests..."
+& "$PSScriptRoot\tests\spec_custom_fields_validate.ps1"
+
 Write-Host "[test_all] DONE"
 Exit 0

--- a/PS1/tests/spec_custom_fields_validate.ps1
+++ b/PS1/tests/spec_custom_fields_validate.ps1
@@ -1,0 +1,100 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+# Validateur de definition de champ custom (v1)
+$AllowedTypes = @("string","int","date","enum")
+$NamePattern  = '^[a-z][a-z0-9_]{1,30}$'
+
+function Test-CFDefinition {
+  param([hashtable]$Def, [hashtable]$RegistryPerScope)
+
+  # Champs requis
+  foreach ($k in @("name","label","type")) {
+    if (-not $Def.ContainsKey($k)) { throw "Champ requis manquant: $k" }
+  }
+  if (-not ($Def.label -is [hashtable] -and $Def.label.fr -and $Def.label.en)) {
+    throw "Labels FR/EN requis"
+  }
+
+  # Name format + unicite
+  if ($Def.name -notmatch $NamePattern) { throw "Nom invalide: $($Def.name)" }
+  $scope = $Def.scope
+  if ([string]::IsNullOrWhiteSpace($scope)) { $scope = "employee" }
+  if (-not $RegistryPerScope.ContainsKey($scope)) { $RegistryPerScope[$scope] = @{} }
+  if ($RegistryPerScope[$scope].ContainsKey($Def.name)) { throw "Nom deja utilise dans le scope: $scope/$($Def.name)" }
+
+  # Type autorise
+  if ($AllowedTypes -notcontains $Def.type) { throw "Type invalide: $($Def.type)" }
+
+  # Validations par type
+  if ($Def.type -eq "string") {
+    $min = $Def.validations.min_length
+    $max = $Def.validations.max_length
+    if ($min -and $min -lt 0) { throw "min_length < 0" }
+    if ($max -and $min -and ($max -lt $min)) { throw "max_length < min_length" }
+  }
+  elseif ($Def.type -eq "int") {
+    $min = $Def.validations.min
+    $max = $Def.validations.max
+    if ($max -and $min -and ($max -lt $min)) { throw "max < min (int)" }
+    if ($Def.default -and ($Def.default -as [int]) -isnot [int]) { throw "default non entier" }
+  }
+  elseif ($Def.type -eq "date") {
+    $min = $Def.validations.min_date
+    $max = $Def.validations.max_date
+    if ($min -and (-not ($min -match '^\d{4}-\d{2}-\d{2}$'))) { throw "min_date format invalide" }
+    if ($max -and (-not ($max -match '^\d{4}-\d{2}-\d{2}$'))) { throw "max_date format invalide" }
+    if ($min -and $max -and ([string]$max -lt [string]$min)) { throw "max_date < min_date" }
+  }
+  elseif ($Def.type -eq "enum") {
+    if (-not $Def.enum_values -or $Def.enum_values.Count -lt 1) { throw "enum_values requis (>=1)" }
+    $uniq = $Def.enum_values | Select-Object -Unique
+    if ($uniq.Count -ne $Def.enum_values.Count) { throw "enum_values dupliques" }
+  }
+
+  # Si tout va bien, enregistrer
+  $RegistryPerScope[$scope][$Def.name] = $true
+  return $true
+}
+
+# Registry in-memory des noms utilises (par scope)
+$reg = @{}
+
+# 1) OK: creation d'un champ string valide
+$cfOK = @{
+  scope = "employee"
+  name  = "badge_interne"
+  label = @{ fr="Badge interne"; en="Internal badge" }
+  type  = "string"
+  required = $true
+  validations = @{ min_length=4; max_length=12; regex='^[A-Z0-9-]{4,12}$' }
+}
+try {
+  $res = Test-CFDefinition -Def $cfOK -RegistryPerScope $reg
+  if (-not $res) { Write-Host "[KO] creation champ string valide a echoue" ; exit 1 }
+  Write-Host "[OK] champ string valide cree"
+} catch {
+  Write-Host "[KO] exception inattendue (OK case): $($_.Exception.Message)" ; exit 1
+}
+
+# 2) KO: enum sans valeurs -> rejet
+$cfKO = @{
+  scope = "employee"
+  name  = "habilitation_caces"
+  label = @{ fr="Habilitation CACES"; en="CACES certification" }
+  type  = "enum"
+  enum_values = @()   # vide -> doit echouer
+}
+$failed = $false
+try {
+  $null = Test-CFDefinition -Def $cfKO -RegistryPerScope $reg
+  Write-Host "[KO] enum sans valeurs aurait du etre refuse" ; $failed = $true
+} catch {
+  if ($_.Exception.Message -notmatch "enum_values requis") {
+    Write-Host "[KO] message d'erreur inattendu: $($_.Exception.Message)" ; $failed = $true
+  } else {
+    Write-Host "[OK] enum sans valeurs rejete (attendu)"
+  }
+}
+if ($failed) { exit 1 } else { Write-Host "spec custom fields tests: PASS"; exit 0 }
+

--- a/PS1/tools/docs_guard.ps1
+++ b/PS1/tools/docs_guard.ps1
@@ -90,5 +90,16 @@ if (-not (Test-Path (Join-Path $root $specMdI18n))) {
   Write-Error "docs_guard: $specMdI18n missing"
 }
 
+$specMdCF = "docs/specs/custom_fields_v1.md"
+if ($readmeText -notmatch [regex]::Escape($specMdCF)) {
+  Write-Error "docs_guard: README must reference $specMdCF"
+}
+if ($indexText -notmatch "Custom Fields v1") {
+  Write-Error "docs_guard: index.md must mention Custom Fields v1"
+}
+if (-not (Test-Path (Join-Path $root $specMdCF))) {
+  Write-Error "docs_guard: $specMdCF missing"
+}
+
 Write-Host "docs_guard: OK"
 Exit 0

--- a/README.md
+++ b/README.md
@@ -169,6 +169,28 @@ pwsh -NoLogo -NoProfile -File PS1\test_all.ps1
 
 ```
 
+## Custom Fields v1 (Etape 8)
+- Spec: `docs/specs/custom_fields_v1.md` (v1.0.0).
+- Export:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\specs\export_custom_fields.ps1
+
+```
+- Tests:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\tests\spec_custom_fields_validate.ps1
+
+```
+- Packs rapides:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\smoke.ps1
+pwsh -NoLogo -NoProfile -File PS1\test_all.ps1
+
+```
+
 ## Scripts
 - `PS1\dev_up.ps1` : mise en route locale (etape 0: no-op).
 - `PS1\test_all.ps1` : lance le garde-fou de la roadmap.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -14,6 +14,7 @@ Chaque etape contient: Titre, Objectif, Livrables, Scripts, Tests, CI Gates, Acc
   - Etape 5 - Parametres entreprise: voir `docs/specs/org_settings_v1.md` (v1.0.0). Parametres critiques: timezone_default, devise_default, locale_default, formats.
   - Etape 6 - Notifications systeme: voir `docs/specs/notifications_v1.md` (v1.0.0). Triggers + templates (placeholders {{var}}).
   - Etape 7 - Support multilingue (UI): voir `docs/specs/i18n_v1.md` (i18n v1.0.0). Fallback -> FR; cles `domaine.sousdomaine.element`.
+  - Etape 8 - Champs personnalises: voir `docs/specs/custom_fields_v1.md` (v1.0.0). Types: string/int/date/enum; unicite du name par scope.
 - roadmap_11-20.md : RH de base & planification (11-20)
 - roadmap_21-30.md : Conges, absences, temps (21-30)
 - roadmap_31-40.md : Conges, absences, temps (31-40)
@@ -41,6 +42,8 @@ Chaque etape contient: Titre, Objectif, Livrables, Scripts, Tests, CI Gates, Acc
 - [Auth v1](../specs/auth_v1.md)
 - [Org Settings v1](../specs/org_settings_v1.md)
 - [Notifications v1](../specs/notifications_v1.md)
+- [i18n v1](../specs/i18n_v1.md)
+- [Custom Fields v1](../specs/custom_fields_v1.md)
 
 ## Rattachements aux themes de la source fournie
 - RH de base & planification: employes, organigramme, roles, auth, parametres, notifications, multilingue, champs personnalises, import/export, journalisation, plannings, disponibilites, conflits, auto-planification, sync calendrier, historique, multi-sites, creneaux speciaux, notifications planning, rapports planning.

--- a/docs/specs/custom_fields_v1.md
+++ b/docs/specs/custom_fields_v1.md
@@ -1,0 +1,44 @@
+# Spec - Custom Fields v1
+
+Version: 1.0.0
+Objet: definir un mecanisme generique de champs personnalises rattaches a l'entite Employe.
+
+## Portee v1
+- Portee (scope): `employee` uniquement (v2: autres entites).
+- Types autorises: `string`, `int`, `date`, `enum`.
+
+## Modele de definition (conceptuel)
+- name: string (snake_case recommande), requis, unique par scope, pattern ^[a-z][a-z0-9_]{1,30}$
+- label:
+  - fr: string [1..80], requis
+  - en: string [1..80], requis
+- type: enum {string,int,date,enum}, requis
+- required: bool (defaut: false)
+- default: valeur optionnelle (doit respecter le type)
+- validations (selon type):
+  - string: min_length? (>=0), max_length? (>=min), regex? (string)
+  - int: min?, max? (min <= max si definis)
+  - date: min_date?, max_date? (ISO yyyy-MM-dd; min <= max si definis)
+  - enum: enum_values: [string >=1], required si type=enum
+- visibility: enum {public, private} (defaut: public)
+- editable: bool (defaut: true)
+- help_text:
+  - fr?: string [0..200]
+  - en?: string [0..200]
+
+## Contraintes
+- Unicite du `name` par scope (employee).
+- Pour type=enum: `enum_values` doit contenir >= 1 valeur unique (case-sensitive autorisee).
+- Valeur par defaut, si fournie, doit satisfaire les validations.
+- Longueurs et bornes coherentes (min <= max).
+
+## Exemples d'usage (FR)
+- `badge_interne` (string, regex ^[A-Z0-9-]{4,12}$)
+- `habilitation_caces` (enum: ["R389_1","R389_3","R489_A","R489_B"])
+- `date_medicale` (date, min_date=2020-01-01)
+- `coef_conventionnel` (int, min=100, max=999)
+
+## Acceptation
+- 1 OK: creation d'un champ `string` valide.
+- 1 KO: definition `enum` sans valeurs -> rejet avec message clair.
+


### PR DESCRIPTION
## Summary
- add Custom Fields v1 spec and export script
- validate custom field definitions with PowerShell tests (string OK, enum missing values rejected)
- wire docs guard, roadmap, README, and CI for Custom Fields v1

## Testing
- `pwsh -NoLogo -NoProfile -File PS1/specs/export_custom_fields.ps1` *(fails: pwsh not found)*
- `pwsh -NoLogo -NoProfile -File PS1/tests/spec_custom_fields_validate.ps1` *(fails: pwsh not found)*
- `pwsh -NoLogo -NoProfile -File PS1/smoke.ps1` *(fails: pwsh not found)*
- `pwsh -NoLogo -NoProfile -File PS1/test_all.ps1` *(fails: pwsh not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b77fc8461483308792dc8ad000417b