### PR TITLE
step-9: import/export v1 spec + samples + CSV tests + docs updates

### DIFF
--- a/.github/workflows/docs-guard.yml
+++ b/.github/workflows/docs-guard.yml
@@ -22,6 +22,7 @@ jobs:
           ./PS1/specs/export_notifications.ps1
           ./PS1/specs/export_i18n.ps1
           ./PS1/specs/export_custom_fields.ps1
+          ./PS1/specs/export_import.ps1
       - name: Run docs guard
         shell: pwsh
         run: |

--- a/PS1/smoke.ps1
+++ b/PS1/smoke.ps1
@@ -40,5 +40,7 @@ Write-Host "[smoke] Export i18n..."
 & "$PSScriptRoot\specs\export_custom_fields.ps1"
 & "$PSScriptRoot\tests\spec_custom_fields_validate.ps1"
 
+& "$PSScriptRoot\specs\export_import.ps1"
+& "$PSScriptRoot\tests\spec_import_csv.ps1"
 Write-Host "[smoke] OK"
 Exit 0

--- a/PS1/specs/export_import.ps1
+++ b/PS1/specs/export_import.ps1
@@ -1,0 +1,78 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$root    = Resolve-Path "$PSScriptRoot\..\.."
+$specDir = Join-Path $root "docs\specs"
+$sampleDir = Join-Path $root "docs\samples"
+New-Item -ItemType Directory -Force -Path $specDir   | Out-Null
+New-Item -ItemType Directory -Force -Path $sampleDir | Out-Null
+
+# Write spec MD
+$mdPath = Join-Path $specDir "import_export_v1.md"
+$md = @'
+# Spec - Import/Export v1
+
+Version: 1.0.0
+Objet: definir le format CSV/Excel d'echange des employes et les regles de mapping/validation.
+
+## Format CSV (UTF-8, ; separateur)
+Colonnes et types:
+- id (UUID, optionnel a l'import; genere si vide)
+- nom (string 2..100, requis)
+- prenom (string 1..100, requis)
+- email (string, requis, unique, format email v1)
+- telephone (string, optionnel)
+- role_metier (string, optionnel)
+- service (string, optionnel)
+- site (string, optionnel)
+- statut (string enum: actif|inactif|archive; defaut actif)
+- date_entree (date ISO yyyy-MM-dd, optionnel)
+- date_sortie (date ISO yyyy-MM-dd, optionnel)
+- contrat_type (enum: CDI|CDD|Intermittent|Freelance|Stage|Autre, optionnel)
+- temps_travail (number 0..100, optionnel)
+- manager_email (string, optionnel; mapping vers manager_id)
+
+## Regles de validation
+- email: format conforme a employee_v1 + unicite dans le fichier ET en base (intra-fichier v1).
+- date_sortie >= date_entree si presentes.
+- statut conforme a l'enum.
+- Si manager_email renseigne, il doit exister (ou etre resolu dans un second passage v2).
+
+## Mapping (v1)
+- manager_email -> manager_id (resolution exterieure au scope de ce lot).
+- colonnes non reconnues -> ignorees (warning).
+
+## Erreurs
+- Rapport CSV/texte listant: ligne, colonne, erreur (FR), code (ex: EMAIL_DUPLICATE).
+
+## Exemples (voir /docs/samples)
+- employees_sample_ok.csv : 1 ligne valide.
+- employees_sample_dup.csv : 2 lignes dont doublon email -> KO.
+
+## Acceptation
+- 1 OK: import d'une ligne valide.
+- 1 KO: doublon email -> echec avec message.
+
+---
+'@
+Set-Content -LiteralPath $mdPath -Value $md -Encoding UTF8
+
+# Samples
+$okCsvPath = Join-Path $sampleDir "employees_sample_ok.csv"
+$dupCsvPath = Join-Path $sampleDir "employees_sample_dup.csv"
+
+$ok = @'
+id;nom;prenom;email;telephone;role_metier;service;site;statut;date_entree;date_sortie;contrat_type;temps_travail;manager_email
+;courtois;alice;alice.courtois@example.com;;administratif;RH;PARIS;actif;2025-01-10;;CDI;100;
+'@
+Set-Content -LiteralPath $okCsvPath -Value $ok -Encoding UTF8
+
+$dup = @'
+id;nom;prenom;email;telephone;role_metier;service;site;statut;date_entree;date_sortie;contrat_type;temps_travail;manager_email
+;dupont;bob;dup@example.com;;technicien;OPS;PARIS;actif;2024-03-01;;CDD;80;
+;durand;carla;dup@example.com;;technicien;OPS;PARIS;actif;2024-04-01;;CDD;80;
+'@
+Set-Content -LiteralPath $dupCsvPath -Value $dup -Encoding UTF8
+
+Write-Host "export_import: wrote $mdPath, $okCsvPath and $dupCsvPath"
+Exit 0

--- a/PS1/test_all.ps1
+++ b/PS1/test_all.ps1
@@ -44,5 +44,10 @@ Write-Host "[test_all] Exporting custom fields spec..."
 Write-Host "[test_all] Running custom fields tests..."
 & "$PSScriptRoot\tests\spec_custom_fields_validate.ps1"
 
+Write-Host "[test_all] Exporting import/export spec & samples..."
+& "$PSScriptRoot\specs\export_import.ps1"
+Write-Host "[test_all] Running import/export CSV tests..."
+& "$PSScriptRoot\tests\spec_import_csv.ps1"
+
 Write-Host "[test_all] DONE"
 Exit 0

--- a/PS1/tests/spec_import_csv.ps1
+++ b/PS1/tests/spec_import_csv.ps1
@@ -1,0 +1,71 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+function Read-CsvSemicolon {
+  param([string]$Path)
+  $lines = Get-Content -LiteralPath $Path
+  if ($lines.Count -lt 2) { throw "CSV vide ou entete seule: $Path" }
+  $header = $lines[0].Split(";")
+  $rows = @()
+  for ($i=1; $i -lt $lines.Count; $i++) {
+    $cols = $lines[$i].Split(";")
+    $obj = [ordered]@{}
+    for ($c=0; $c -lt $header.Length; $c++) { $obj[$header[$c]] = $cols[$c] }
+    $rows += [pscustomobject]$obj
+  }
+  return ,$rows
+}
+
+# Simple email regex (align employee_v1)
+$EmailRegex = '^[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}$'
+
+function Validate-EmployeesCsv {
+  param([string]$Path)
+  $rows = Read-CsvSemicolon -Path $Path
+  $errors = @()
+  $seenEmails = @{}
+
+  for ($i=0; $i -lt $rows.Count; $i++) {
+    $r = $rows[$i]
+    $lineNo = $i + 2 # header is line 1
+    $email = ($r.email).Trim()
+    $nom   = ($r.nom).Trim()
+    $prenom= ($r.prenom).Trim()
+
+    if ([string]::IsNullOrWhiteSpace($nom))    { $errors += "L$lineNo;nom;REQUIRED" }
+    if ([string]::IsNullOrWhiteSpace($prenom)) { $errors += "L$lineNo;prenom;REQUIRED" }
+    if ([string]::IsNullOrWhiteSpace($email))  { $errors += "L$lineNo;email;REQUIRED" }
+    elseif ($email -notmatch $EmailRegex)      { $errors += "L$lineNo;email;INVALID_FORMAT" }
+    elseif ($seenEmails.ContainsKey($email))   { $errors += "L$lineNo;email;EMAIL_DUPLICATE" }
+    else { $seenEmails[$email] = $true }
+  }
+
+  return ,$errors
+}
+
+$root = Resolve-Path "$PSScriptRoot\..\.."
+$okCsv  = Join-Path $root "docs\samples\employees_sample_ok.csv"
+$dupCsv = Join-Path $root "docs\samples\employees_sample_dup.csv"
+
+if (-not (Test-Path $okCsv -PathType Leaf)) { Write-Error "Sample manquant: $okCsv (run export_import.ps1)" }
+if (-not (Test-Path $dupCsv -PathType Leaf)) { Write-Error "Sample manquant: $dupCsv (run export_import.ps1)" }
+
+# 1) OK: import d'une ligne valide
+$errsOK = Validate-EmployeesCsv -Path $okCsv
+if ($errsOK.Count -ne 0) {
+  Write-Host "[KO] sample OK devrait avoir 0 erreur, trouve: $($errsOK -join ', ')" ; exit 1
+} else {
+  Write-Host "[OK] sample OK valide (0 erreur)"
+}
+
+# 2) KO: doublon email -> echec avec rapport
+$errsDup = Validate-EmployeesCsv -Path $dupCsv
+if (-not ($errsDup | Where-Object { $_ -match "EMAIL_DUPLICATE" })) {
+  Write-Host "[KO] attendu EMAIL_DUPLICATE dans sample KO, erreurs: $($errsDup -join ', ')" ; exit 1
+} else {
+  Write-Host "[OK] doublon email detecte (EMAIL_DUPLICATE)"
+  Write-Host "Rapport: $($errsDup -join '; ')"
+}
+
+Write-Host "spec import/export CSV tests: PASS"
+Exit 0

--- a/PS1/tools/docs_guard.ps1
+++ b/PS1/tools/docs_guard.ps1
@@ -101,5 +101,17 @@ if (-not (Test-Path (Join-Path $root $specMdCF))) {
   Write-Error "docs_guard: $specMdCF missing"
 }
 
+$specMdImport = "docs/specs/import_export_v1.md"
+
+if ($readmeText -notmatch [regex]::Escape($specMdImport)) {
+  Write-Error "docs_guard: README must reference $specMdImport"
+}
+if ($indexText -notmatch "Import/Export v1") {
+  Write-Error "docs_guard: index.md must mention Import/Export v1"
+}
+if (-not (Test-Path (Join-Path $root $specMdImport))) {
+  Write-Error "docs_guard: $specMdImport missing"
+}
+
 Write-Host "docs_guard: OK"
 Exit 0

--- a/README.md
+++ b/README.md
@@ -191,6 +191,29 @@ pwsh -NoLogo -NoProfile -File PS1\test_all.ps1
 
 ```
 
+## Import/Export v1 (Etape 9)
+- Spec: `docs/specs/import_export_v1.md` (v1.0.0).
+- Samples: `docs/samples/employees_sample_ok.csv`, `docs/samples/employees_sample_dup.csv`.
+- Export:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\specs\export_import.ps1
+
+```
+- Tests:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\tests\spec_import_csv.ps1
+
+```
+- Packs rapides:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\smoke.ps1
+pwsh -NoLogo -NoProfile -File PS1\test_all.ps1
+
+```
+
 ## Scripts
 - `PS1\dev_up.ps1` : mise en route locale (etape 0: no-op).
 - `PS1\test_all.ps1` : lance le garde-fou de la roadmap.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -15,6 +15,7 @@ Chaque etape contient: Titre, Objectif, Livrables, Scripts, Tests, CI Gates, Acc
   - Etape 6 - Notifications systeme: voir `docs/specs/notifications_v1.md` (v1.0.0). Triggers + templates (placeholders {{var}}).
   - Etape 7 - Support multilingue (UI): voir `docs/specs/i18n_v1.md` (i18n v1.0.0). Fallback -> FR; cles `domaine.sousdomaine.element`.
   - Etape 8 - Champs personnalises: voir `docs/specs/custom_fields_v1.md` (v1.0.0). Types: string/int/date/enum; unicite du name par scope.
+  - Etape 9 - Import/Export de donnees: voir `docs/specs/import_export_v1.md` (v1.0.0). CSV employes (UTF-8, ;) + unicite email intra-fichier.
 - roadmap_11-20.md : RH de base & planification (11-20)
 - roadmap_21-30.md : Conges, absences, temps (21-30)
 - roadmap_31-40.md : Conges, absences, temps (31-40)
@@ -44,6 +45,7 @@ Chaque etape contient: Titre, Objectif, Livrables, Scripts, Tests, CI Gates, Acc
 - [Notifications v1](../specs/notifications_v1.md)
 - [i18n v1](../specs/i18n_v1.md)
 - [Custom Fields v1](../specs/custom_fields_v1.md)
+- [Import/Export v1](../specs/import_export_v1.md)
 
 ## Rattachements aux themes de la source fournie
 - RH de base & planification: employes, organigramme, roles, auth, parametres, notifications, multilingue, champs personnalises, import/export, journalisation, plannings, disponibilites, conflits, auto-planification, sync calendrier, historique, multi-sites, creneaux speciaux, notifications planning, rapports planning.

--- a/docs/samples/employees_sample_dup.csv
+++ b/docs/samples/employees_sample_dup.csv
@@ -1,0 +1,3 @@
+id;nom;prenom;email;telephone;role_metier;service;site;statut;date_entree;date_sortie;contrat_type;temps_travail;manager_email
+;dupont;bob;dup@example.com;;technicien;OPS;PARIS;actif;2024-03-01;;CDD;80;
+;durand;carla;dup@example.com;;technicien;OPS;PARIS;actif;2024-04-01;;CDD;80;

--- a/docs/samples/employees_sample_ok.csv
+++ b/docs/samples/employees_sample_ok.csv
@@ -1,0 +1,2 @@
+id;nom;prenom;email;telephone;role_metier;service;site;statut;date_entree;date_sortie;contrat_type;temps_travail;manager_email
+;courtois;alice;alice.courtois@example.com;;administratif;RH;PARIS;actif;2025-01-10;;CDI;100;

--- a/docs/specs/import_export_v1.md
+++ b/docs/specs/import_export_v1.md
@@ -1,0 +1,44 @@
+# Spec - Import/Export v1
+
+Version: 1.0.0
+Objet: definir le format CSV/Excel d'echange des employes et les regles de mapping/validation.
+
+## Format CSV (UTF-8, ; separateur)
+Colonnes et types:
+- id (UUID, optionnel a l'import; genere si vide)
+- nom (string 2..100, requis)
+- prenom (string 1..100, requis)
+- email (string, requis, unique, format email v1)
+- telephone (string, optionnel)
+- role_metier (string, optionnel)
+- service (string, optionnel)
+- site (string, optionnel)
+- statut (string enum: actif|inactif|archive; defaut actif)
+- date_entree (date ISO yyyy-MM-dd, optionnel)
+- date_sortie (date ISO yyyy-MM-dd, optionnel)
+- contrat_type (enum: CDI|CDD|Intermittent|Freelance|Stage|Autre, optionnel)
+- temps_travail (number 0..100, optionnel)
+- manager_email (string, optionnel; mapping vers manager_id)
+
+## Regles de validation
+- email: format conforme a employee_v1 + unicite dans le fichier ET en base (intra-fichier v1).
+- date_sortie >= date_entree si presentes.
+- statut conforme a l'enum.
+- Si manager_email renseigne, il doit exister (ou etre resolu dans un second passage v2).
+
+## Mapping (v1)
+- manager_email -> manager_id (resolution exterieure au scope de ce lot).
+- colonnes non reconnues -> ignorees (warning).
+
+## Erreurs
+- Rapport CSV/texte listant: ligne, colonne, erreur (FR), code (ex: EMAIL_DUPLICATE).
+
+## Exemples (voir /docs/samples)
+- employees_sample_ok.csv : 1 ligne valide.
+- employees_sample_dup.csv : 2 lignes dont doublon email -> KO.
+
+## Acceptation
+- 1 OK: import d'une ligne valide.
+- 1 KO: doublon email -> echec avec message.
+
+---


### PR DESCRIPTION
## Summary
- add Import/Export v1 spec and sample CSVs
- provide export script and PowerShell CSV validation tests
- wire docs guard, roadmap, README and CI for Import/Export v1

## Testing
- `pwsh -NoLogo -NoProfile -File PS1/specs/export_import.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/tests/spec_import_csv.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/tools/docs_guard.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/smoke.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/test_all.ps1`


------
https://chatgpt.com/codex/tasks/task_e_68b7822b0d38833091f70dad3f939aa9