### PR TITLE
step-10: audit log v1 spec + export + schema tests + docs updates

### DIFF
--- a/.github/workflows/docs-guard.yml
+++ b/.github/workflows/docs-guard.yml
@@ -23,6 +23,7 @@ jobs:
           ./PS1/specs/export_i18n.ps1
           ./PS1/specs/export_custom_fields.ps1
           ./PS1/specs/export_import.ps1
+          ./PS1/specs/export_audit.ps1
       - name: Run docs guard
         shell: pwsh
         run: |

--- a/PS1/smoke.ps1
+++ b/PS1/smoke.ps1
@@ -42,5 +42,9 @@ Write-Host "[smoke] Export i18n..."
 
 & "$PSScriptRoot\specs\export_import.ps1"
 & "$PSScriptRoot\tests\spec_import_csv.ps1"
+Write-Host "[smoke] Export audit spec..."
+& "$PSScriptRoot\specs\export_audit.ps1"
+Write-Host "[smoke] Audit schema quick test..."
+& "$PSScriptRoot\tests\spec_audit_schema.ps1"
 Write-Host "[smoke] OK"
 Exit 0

--- a/PS1/specs/export_audit.ps1
+++ b/PS1/specs/export_audit.ps1
@@ -1,0 +1,59 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$root   = Resolve-Path "$PSScriptRoot\..\.."
+$specDir= Join-Path $root "docs\specs"
+New-Item -ItemType Directory -Force -Path $specDir | Out-Null
+
+$mdPath = Join-Path $specDir "audit_log_v1.md"
+$md = @'
+# Spec - Audit Log v1
+
+Version: 1.0.0
+Objet: definir le schema JSON minimal des evenements de journalisation et les regles de validation (UTC, champs requis).
+
+## Champs (obligatoires sauf mention)
+- request_id: string (UUID v4 recommande)
+- actor_id: string (UUID ou "system")
+- resource: string (ex: "employee", "auth", "import")
+- action: string (ex: "create", "update", "delete", "login_ok", "login_ko", "import_run")
+- timestamp: string ISO 8601 en **UTC** (suffixe "Z"), ex: 2025-09-03T12:34:56.789Z
+- details: objet JSON (key/value libres; pas de secrets)
+
+## Niveaux et retention (minima)
+- niveau: info|warning|error (defaut: info)
+- retention: 90 jours (minima) en stockage primaire; export possible (v2)
+
+## Exemples
+OK (CRUD employee/create):
+{
+  "request_id": "b9a1c3af-3a7d-4a2f-8d5b-0b3b9c68f111",
+  "actor_id": "3d1f2b0a-0d8f-44e5-9a1c-111122223333",
+  "resource": "employee",
+  "action": "create",
+  "timestamp": "2025-09-03T10:00:00.000Z",
+  "level": "info",
+  "details": { "employee_email": "alice.courtois@example.com" }
+}
+
+KO (timestamp non UTC):
+{
+  "request_id": "b9a1c3af-3a7d-4a2f-8d5b-0b3b9c68f111",
+  "actor_id": "system",
+  "resource": "auth",
+  "action": "login_ok",
+  "timestamp": "2025-09-03T12:34:56+02:00",  // interdit: pas de "Z"
+  "details": { "user": "bob@example.com" }
+}
+
+## Acceptation
+- 1 OK: evenement conforme au schema.
+- 1 KO: timestamp sans "Z" -> non conforme.
+
+## Notes
+- OpenTelemetry optionnel plus tard; mapping vers ce schema au niveau collector.
+'@
+Set-Content -LiteralPath $mdPath -Value $md -Encoding UTF8
+
+Write-Host "export_audit: wrote $mdPath"
+Exit 0

--- a/PS1/test_all.ps1
+++ b/PS1/test_all.ps1
@@ -49,5 +49,10 @@ Write-Host "[test_all] Exporting import/export spec & samples..."
 Write-Host "[test_all] Running import/export CSV tests..."
 & "$PSScriptRoot\tests\spec_import_csv.ps1"
 
+Write-Host "[test_all] Exporting audit spec..."
+& "$PSScriptRoot\specs\export_audit.ps1"
+Write-Host "[test_all] Running audit schema tests..."
+& "$PSScriptRoot\tests\spec_audit_schema.ps1"
+
 Write-Host "[test_all] DONE"
 Exit 0

--- a/PS1/tests/spec_audit_schema.ps1
+++ b/PS1/tests/spec_audit_schema.ps1
@@ -1,0 +1,57 @@
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+# Regles minimales: champs requis + timestamp ISO 8601 en UTC (suffixe Z)
+function Test-AuditEvent {
+  param([hashtable]$E)
+
+  foreach ($k in @("request_id","actor_id","resource","action","timestamp","details")) {
+    if (-not $E.ContainsKey($k)) { throw "Champ requis manquant: $k" }
+  }
+  # timestamp doit se terminer par Z (UTC)
+  $ts = [string]$E.timestamp
+  if ($ts -notmatch '^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}(\.\d{1,6})?Z$') {
+    throw "Timestamp non UTC (doit finir par 'Z'): $ts"
+  }
+  return $true
+}
+
+# OK: evenement CRUD employee/create conforme
+$ok = @{
+  request_id = "b9a1c3af-3a7d-4a2f-8d5b-0b3b9c68f111"
+  actor_id   = "3d1f2b0a-0d8f-44e5-9a1c-111122223333"
+  resource   = "employee"
+  action     = "create"
+  timestamp  = "2025-09-03T10:00:00.000Z"
+  level      = "info"
+  details    = @{ employee_email = "alice.courtois@example.com" }
+}
+try {
+  $res = Test-AuditEvent -E $ok
+  if (-not $res) { Write-Host "[KO] evenement OK a echoue" ; exit 1 }
+  Write-Host "[OK] evenement CRUD conforme au schema"
+} catch {
+  Write-Host "[KO] exception inattendue (OK case): $($_.Exception.Message)" ; exit 1
+}
+
+# KO: timestamp non UTC (offset +02:00)
+$ko = @{
+  request_id = "b9a1c3af-3a7d-4a2f-8d5b-0b3b9c68f111"
+  actor_id   = "system"
+  resource   = "auth"
+  action     = "login_ok"
+  timestamp  = "2025-09-03T12:34:56+02:00"  # interdit
+  details    = @{ user = "bob@example.com" }
+}
+$failed = $false
+try {
+  $null = Test-AuditEvent -E $ko
+  Write-Host "[KO] evenement KO aurait du etre refuse (timestamp non UTC)" ; $failed = $true
+} catch {
+  if ($_.Exception.Message -notmatch "Timestamp non UTC") {
+    Write-Host "[KO] message d'erreur inattendu: $($_.Exception.Message)" ; $failed = $true
+  } else {
+    Write-Host "[OK] timestamp non UTC correctement refuse"
+  }
+}
+if ($failed) { exit 1 } else { Write-Host "spec audit schema tests: PASS"; exit 0 }

--- a/PS1/tools/docs_guard.ps1
+++ b/PS1/tools/docs_guard.ps1
@@ -113,5 +113,16 @@ if (-not (Test-Path (Join-Path $root $specMdImport))) {
   Write-Error "docs_guard: $specMdImport missing"
 }
 
+$specMdAudit = "docs/specs/audit_log_v1.md"
+if ($readmeText -notmatch [regex]::Escape($specMdAudit)) {
+  Write-Error "docs_guard: README must reference $specMdAudit"
+}
+if ($indexText -notmatch "Audit Log v1") {
+  Write-Error "docs_guard: index.md must mention Audit Log v1"
+}
+if (-not (Test-Path (Join-Path $root $specMdAudit))) {
+  Write-Error "docs_guard: $specMdAudit missing"
+}
+
 Write-Host "docs_guard: OK"
 Exit 0

--- a/README.md
+++ b/README.md
@@ -214,6 +214,28 @@ pwsh -NoLogo -NoProfile -File PS1\test_all.ps1
 
 ```
 
+## Audit Log v1 (Etape 10)
+- Spec: `docs/specs/audit_log_v1.md` (v1.0.0).
+- Export:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\specs\export_audit.ps1
+
+```
+- Tests:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\tests\spec_audit_schema.ps1
+
+```
+- Packs rapides:
+```
+
+pwsh -NoLogo -NoProfile -File PS1\smoke.ps1
+pwsh -NoLogo -NoProfile -File PS1\test_all.ps1
+
+```
+
 ## Scripts
 - `PS1\dev_up.ps1` : mise en route locale (etape 0: no-op).
 - `PS1\test_all.ps1` : lance le garde-fou de la roadmap.

--- a/docs/roadmap/index.md
+++ b/docs/roadmap/index.md
@@ -16,6 +16,7 @@ Chaque etape contient: Titre, Objectif, Livrables, Scripts, Tests, CI Gates, Acc
   - Etape 7 - Support multilingue (UI): voir `docs/specs/i18n_v1.md` (i18n v1.0.0). Fallback -> FR; cles `domaine.sousdomaine.element`.
   - Etape 8 - Champs personnalises: voir `docs/specs/custom_fields_v1.md` (v1.0.0). Types: string/int/date/enum; unicite du name par scope.
   - Etape 9 - Import/Export de donnees: voir `docs/specs/import_export_v1.md` (v1.0.0). CSV employes (UTF-8, ;) + unicite email intra-fichier.
+  - Etape 10 - Journalisation (Audit Log v1): voir `docs/specs/audit_log_v1.md` (v1.0.0). Champs requis + timestamp ISO UTC ("Z").
 - roadmap_11-20.md : RH de base & planification (11-20)
 - roadmap_21-30.md : Conges, absences, temps (21-30)
 - roadmap_31-40.md : Conges, absences, temps (31-40)

--- a/docs/specs/audit_log_v1.md
+++ b/docs/specs/audit_log_v1.md
@@ -1,0 +1,45 @@
+# Spec - Audit Log v1
+
+Version: 1.0.0
+Objet: definir le schema JSON minimal des evenements de journalisation et les regles de validation (UTC, champs requis).
+
+## Champs (obligatoires sauf mention)
+- request_id: string (UUID v4 recommande)
+- actor_id: string (UUID ou "system")
+- resource: string (ex: "employee", "auth", "import")
+- action: string (ex: "create", "update", "delete", "login_ok", "login_ko", "import_run")
+- timestamp: string ISO 8601 en **UTC** (suffixe "Z"), ex: 2025-09-03T12:34:56.789Z
+- details: objet JSON (key/value libres; pas de secrets)
+
+## Niveaux et retention (minima)
+- niveau: info|warning|error (defaut: info)
+- retention: 90 jours (minima) en stockage primaire; export possible (v2)
+
+## Exemples
+OK (CRUD employee/create):
+{
+  "request_id": "b9a1c3af-3a7d-4a2f-8d5b-0b3b9c68f111",
+  "actor_id": "3d1f2b0a-0d8f-44e5-9a1c-111122223333",
+  "resource": "employee",
+  "action": "create",
+  "timestamp": "2025-09-03T10:00:00.000Z",
+  "level": "info",
+  "details": { "employee_email": "alice.courtois@example.com" }
+}
+
+KO (timestamp non UTC):
+{
+  "request_id": "b9a1c3af-3a7d-4a2f-8d5b-0b3b9c68f111",
+  "actor_id": "system",
+  "resource": "auth",
+  "action": "login_ok",
+  "timestamp": "2025-09-03T12:34:56+02:00",  // interdit: pas de "Z"
+  "details": { "user": "bob@example.com" }
+}
+
+## Acceptation
+- 1 OK: evenement conforme au schema.
+- 1 KO: timestamp sans "Z" -> non conforme.
+
+## Notes
+- OpenTelemetry optionnel plus tard; mapping vers ce schema au niveau collector.


### PR DESCRIPTION
## Summary
- define Audit Log v1 JSON schema with examples and retention rules
- add PowerShell export and schema validation tests (UTC timestamp enforced)
- reference Audit Log v1 in docs guard, roadmap, README, and CI workflow

## Testing
- `pwsh -NoLogo -NoProfile -File PS1/specs/export_audit.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/tests/spec_audit_schema.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/tools/docs_guard.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/smoke.ps1`
- `pwsh -NoLogo -NoProfile -File PS1/test_all.ps1`


------
https://chatgpt.com/codex/tasks/task_e_68b78487e834833095d3b551b3099a96