### PR TITLE
Fix roadmap guard quoting

### DIFF
--- a/docs/guards/README.md
+++ b/docs/guards/README.md
@@ -1,0 +1,6 @@
+## PowerShell ParserError with -f and quotes
+If you see `Unexpected token '{'` from `roadmap_guard.ps1`, the error is due to invalid quoting like `"` inside a formatted string. Fix by using:
+
+- single quotes around `{0}` in the format string, e.g.:
+  `throw ("Missing ... '{0}'" -f $requiredRef)`
+- or PowerShell backtick to escape quotes: `` `" `` when needed.

--- a/tools/guards/roadmap_guard.ps1
+++ b/tools/guards/roadmap_guard.ps1
@@ -6,16 +6,22 @@ function Get-LastCommitMessage { git log -1 --pretty=%B }
 function Get-PRBody {
   if ($env:PR_BODY) { return $env:PR_BODY }
   if ($env:GITHUB_EVENT_NAME -eq 'pull_request') {
-    try { $b = gh pr view --json body -q .body 2>$null; if ($LASTEXITCODE -eq 0 -and $b) { return $b } } catch {}
+    try {
+      $b = gh pr view --json body -q .body 2>$null
+      if ($LASTEXITCODE -eq 0 -and $b) { return $b }
+    } catch { }
   }
   return ''
 }
 
 $commitMessage = Get-LastCommitMessage
-if (-not $commitMessage.Contains($requiredRef)) { throw ("Missing roadmap reference in LAST COMMIT. Expected line: \"{0}\"" -f $requiredRef) }
+if ([string]::IsNullOrWhiteSpace($commitMessage) -or -not ($commitMessage -like "*${requiredRef}*")) {
+  throw ("Missing roadmap reference in LAST COMMIT. Expected line: '{0}'" -f $requiredRef)
+}
 
 $prBody = Get-PRBody
-if ($env:GITHUB_EVENT_NAME -eq 'pull_request' -and -not $prBody.Contains($requiredRef)) {
-  throw ("Missing roadmap reference in PR BODY. Expected line: \"{0}\"" -f $requiredRef)
+if ($env:GITHUB_EVENT_NAME -eq 'pull_request' -and -not ($prBody -like "*${requiredRef}*")) {
+  throw ("Missing roadmap reference in PR BODY. Expected line: '{0}'" -f $requiredRef)
 }
+
 Write-Host 'roadmap_guard OK'


### PR DESCRIPTION
## Summary
- fix roadmap guard formatting to avoid PowerShell parser errors and enforce the roadmap reference in commits and PRs
- add troubleshooting guidance for roadmap guard quoting issues

## Testing
- unable to run `pwsh -File tools/guards/run_all_guards.ps1` (pwsh not installed)

Ref: docs/roadmap/step-02.md

------
https://chatgpt.com/codex/tasks/task_e_68d250b955d8833089028ac993687eca